### PR TITLE
fix(facility):if shortname is empty use name

### DIFF
--- a/src/app/applications/applications.component.ts
+++ b/src/app/applications/applications.component.ts
@@ -144,7 +144,7 @@ export class ApplicationsComponent {
                                 a.Id = aj["project_application_id"];
 
                                 a.Name = aj["project_application_name"];
-                                 a.Shortname=aj["project_application_shortname"];
+                                a.Shortname=aj["project_application_shortname"];
                                 a.Description = aj["project_application_description"];
                                 a.Lifetime = aj["project_application_lifetime"];
 
@@ -165,6 +165,7 @@ export class ApplicationsComponent {
                                 a.Status = aj["project_application_status"];
                                 a.OpenStackProject = aj["project_application_openstack_project"];
                                 if (a.Status !== 1) {
+                                    if (a.Shortname){
                                     this.groupservice.getFacilityByGroup(a.Shortname).subscribe(result => {
 
                                         let details = result['Details'];
@@ -179,7 +180,25 @@ export class ApplicationsComponent {
 
                                         this.all_applications.push(a)
 
+                                    })}
+                                    else {
+                                         this.groupservice.getFacilityByGroup(a.Name).subscribe(result => {
+
+                                        let details = result['Details'];
+                                        let details_array = [];
+                                        for (let detail in details) {
+                                            let detail_tuple = [detail, details[detail]];
+                                            details_array.push(detail_tuple);
+                                        }
+
+                                        a.ComputecenterDetails = details_array;
+                                        a.ComputeCenter = [result['Facility'],result['FacilityID']];
+
+                                        this.all_applications.push(a)
+
                                     })
+
+                                    }
                                 }
                                 else {
                                     a.ComputeCenter = ['None',-1]


### PR DESCRIPTION
if shortname is empty it uses the normal name (for old projects which where created before shortname existed)