### PR TITLE
feat(ssh): opens in new tab

### DIFF
--- a/src/app/userinfo/userinfo.component.html
+++ b/src/app/userinfo/userinfo.component.html
@@ -61,7 +61,7 @@
                                 </div>
                                 <div *ngIf="!validatePublicKey()" class="aler alert-info">
                                     <strong>Info</strong> Insert a valid public Key!<br>
-                                    <a href="https://confluence.csc.fi/pages/viewpage.action?pageId=58826074">How to generate a ssh keypair?</a>
+                                    <a target="_blank" href="https://confluence.csc.fi/pages/viewpage.action?pageId=58826074">How to generate a ssh keypair?</a>
                                 </div>
                                 <div class="alert alert-danger" *ngIf="!validatePublicKey() && public_key?.length >0">
                                     <strong>Warning</strong> This is not a valid public key!


### PR DESCRIPTION
Just a small Convenience change

Before if you click on 'How to generate a ssh keypair' it would open the link at the same tab ,
i think it is better to open it in a new tab 

What do you think?
