### PR TITLE
fix(storageLimit)

### DIFF
--- a/src/app/applications/addcloudapplication.component.html
+++ b/src/app/applications/addcloudapplication.component.html
@@ -189,6 +189,32 @@
                         </accordion-group>
                       </accordion>
 
+
+                      <div class="form-group row">
+                        <label class="col-md-4 form-control-label" for="textarea-input"><strong>Number
+                          of storage
+                          volumes*
+                          <i data-balloon="Number of volumes allowed to create. The sum of the volumes size equals the value provided in the storage limit field."
+                             data-balloon-pos="down" data-balloon-length="large"><i
+                            class="icon-question"
+                            style="cursor: pointer;"></i></i></strong></label>
+                        <div class="col-md-8">
+                          <div class="input-group">
+                            <input required class="form-control"
+                                   id="id_project_application_volume_counter"
+                                   name="project_application_volume_counter"
+                                   placeholder="e.g. 20"
+                                   type="number" min="0" step="1"
+                                   appInteger appMinAmount="0"
+                                   [ngModel]="project_application_vms_requested"
+                                   [ngClass]="{
+                                'is-invalid': f.controls.project_application_volume_counter?.invalid,
+                                'is-valid': f.controls.project_application_volume_counter?.valid
+                                }">
+                          </div>
+                          <span class="help-block">How many storage volumes do you want to use?</span>
+                        </div>
+                      </div>
                         <div class="form-group row">
                             <label class="col-md-4 form-control-label" for="textarea-input"><strong>Storage
                                 Limit*
@@ -207,38 +233,15 @@
                                            [ngClass]="{
                                 'is-invalid': f.controls.project_application_volume_limit?.invalid,
                                 'is-valid': f.controls.project_application_volume_limit?.valid
-                                }">
+                                }"
+                                    [disabled]="f.controls.project_application_volume_counter?.value == 0">
                                   <div class="input-group-append"><span class="input-group-text"> GB </span></div>
                                 </div>
-                                <span class="help-block">How many extra storage do you need for your VMs?</span>
+                                <span class="help-block">How much extra storage do you need for your VMs?</span>
                             </div>
                         </div>
 
-                        <div class="form-group row">
-                            <label class="col-md-4 form-control-label" for="textarea-input"><strong>Number
-                                of storage
-                                volumes*
-                                <i data-balloon="Number of volumes allowed to create. The sum of the volumes size equals the value provided in the storage limit field."
-                                   data-balloon-pos="down" data-balloon-length="large"><i
-                                        class="icon-question"
-                                        style="cursor: pointer;"></i></i></strong></label>
-                            <div class="col-md-8">
-                                <div class="input-group">
-                                    <input required class="form-control"
-                                           id="id_project_application_volume_counter"
-                                           name="project_application_volume_counter"
-                                           placeholder="e.g. 20"
-                                           type="number" min="0" step="1"
-                                           appInteger appMinAmount="0"
-                                           [ngModel]="project_application_vms_requested"
-                                           [ngClass]="{
-                                'is-invalid': f.controls.project_application_volume_counter?.invalid,
-                                'is-valid': f.controls.project_application_volume_counter?.valid
-                                }">
-                                </div>
-                                <span class="help-block">How many storage volumes do you want to use?</span>
-                            </div>
-                        </div>
+
 
                         <div class="form-group row">
                             <label class="col-md-4 form-control-label" for="textarea-input">Object

--- a/src/app/applications/addcloudapplication.component.html
+++ b/src/app/applications/addcloudapplication.component.html
@@ -215,7 +215,7 @@
                           <span class="help-block">How many storage volumes do you want to use?</span>
                         </div>
                       </div>
-                        <div class="form-group row">
+                        <div class="form-group row" [hidden]="f.controls.project_application_volume_counter?.value == 0">
                             <label class="col-md-4 form-control-label" for="textarea-input"><strong>Storage
                                 Limit*
                                 <i

--- a/src/app/applications/addcloudapplication.component.ts
+++ b/src/app/applications/addcloudapplication.component.ts
@@ -123,6 +123,9 @@ export class AddcloudapplicationComponent extends ApplicationBaseClass {
             const values: { [key: string]: string | number | boolean } = {};
             values['project_application_openstack_project'] = this.project_application_openstack_project;
             for (const value in form.controls) {
+                if (form.controls[value].disabled) {
+                  continue;
+                }
                 if (form.controls[value].value) {
 
                     values[value] = form.controls[value].value;

--- a/src/app/applications/addsinglevm.component.html
+++ b/src/app/applications/addsinglevm.component.html
@@ -215,7 +215,7 @@
                           <span class="help-block">How many storage volumes do you want to use?</span>
                         </div>
                       </div>
-                        <div class="form-group row">
+                        <div class="form-group row" [hidden]="f.controls.project_application_volume_counter?.value == 0">
                             <label class="col-md-4 form-control-label" for="textarea-input"><strong>Storage
                                 Limit*
                                 <i

--- a/src/app/applications/addsinglevm.component.html
+++ b/src/app/applications/addsinglevm.component.html
@@ -189,6 +189,32 @@
                           </accordion-group>
                         </ng-container>
                       </accordion>
+                      <div class="form-group row">
+                        <label class="col-md-4 form-control-label" for="textarea-input"><strong>Number
+                          of storage
+                          volumes*
+                          <i
+                            data-balloon="The number of storage volumes allowed to create. Each vm is allowed to mount only one storage volume. The sum of the volumes size equals the value provided in the sotrage limit field"
+                            data-balloon-pos="down" data-balloon-length="large"><i
+                            class="icon-question"
+                            style="cursor: pointer;"></i></i></strong></label>
+                        <div class="col-md-8">
+                          <div class="input-group">
+                            <input required class="form-control"
+                                   id="id_project_application_volume_counter"
+                                   name="project_application_volume_counter"
+                                   placeholder="e.g. 20"
+                                   type="number" min="0" step="1"
+                                   appMinAmount="0" appInteger
+                                   [ngModel]="project_application_vms_requested"
+                                   [ngClass]="{
+                                'is-invalid': f.controls.project_application_volume_counter?.invalid,
+                                'is-valid': f.controls.project_application_volume_counter?.valid
+                                }">
+                          </div>
+                          <span class="help-block">How many storage volumes do you want to use?</span>
+                        </div>
+                      </div>
                         <div class="form-group row">
                             <label class="col-md-4 form-control-label" for="textarea-input"><strong>Storage
                                 Limit*
@@ -208,40 +234,16 @@
                                            [ngClass]="{
                                 'is-invalid': f.controls.project_application_volume_limit?.invalid,
                                 'is-valid': f.controls.project_application_volume_limit?.valid
-                                }">
+                                }"
+                                    [disabled]="f.controls.project_application_volume_counter?.value == 0">
                                     <div class="input-group-append"><span class="input-group-text"> GB
                                     </span></div>
                                 </div>
-                                <span class="help-block">How many extra storage do you need for your VMs?</span>
+                                <span class="help-block">How much extra storage do you need for your VMs?</span>
                             </div>
                         </div>
 
-                        <div class="form-group row">
-                            <label class="col-md-4 form-control-label" for="textarea-input"><strong>Number
-                                of storage
-                                volumes*
-                                <i
-                                        data-balloon="The number of storage volumes allowed to create. Each vm is allowed to mount only one storage volume. The sum of the volumes size equals the value provided in the sotrage limit field"
-                                        data-balloon-pos="down" data-balloon-length="large"><i
-                                        class="icon-question"
-                                        style="cursor: pointer;"></i></i></strong></label>
-                            <div class="col-md-8">
-                                <div class="input-group">
-                                    <input required class="form-control"
-                                           id="id_project_application_volume_counter"
-                                           name="project_application_volume_counter"
-                                           placeholder="e.g. 20"
-                                           type="number" min="0" step="1"
-                                           appMinAmount="0" appInteger
-                                           [ngModel]="project_application_vms_requested"
-                                           [ngClass]="{
-                                'is-invalid': f.controls.project_application_volume_counter?.invalid,
-                                'is-valid': f.controls.project_application_volume_counter?.valid
-                                }">
-                                </div>
-                                <span class="help-block">How many storage volumes do you want to use?</span>
-                            </div>
-                        </div>
+
 
 
                         <br>

--- a/src/app/applications/addsinglevm.component.ts
+++ b/src/app/applications/addsinglevm.component.ts
@@ -136,6 +136,9 @@ export class AddsinglevmComponent extends ApplicationBaseClass {
         } else {
             const values: { [key: string]: string | number | boolean } = {};
             for (const value in form.controls) {
+                if (form.controls[value].disabled) {
+                  continue;
+                }
                 if (form.controls[value].value) {
                     values[value] = form.controls[value].value;
                 }

--- a/src/app/applications/applications.component.html
+++ b/src/app/applications/applications.component.html
@@ -1243,7 +1243,42 @@
                             </accordion-group>
                         </ng-container>
                     </accordion>
+                  <div class="form-group row">
+                    <label class="col-md-4 form-control-label" for="textarea-input"><strong>Number
+                      of storage
+                      volumes*
+                      <i data-balloon="Number of volumes allowed to create. The sum of the volumes size equals the value provided in the storage limit field."
+                         data-balloon-pos="down" data-balloon-length="large"><i
+                        class="icon-question"
+                        style="cursor: pointer;"></i></i></strong></label>
+                    <div class="col">
+                      <div class="input-group">
+                        <input required class="form-control"
+                               name="project_application_volume_counter"
+                               placeholder="NDA"
+                               value="{{selectedApplication?.VolumeCounter}}"
+                               type="text" disabled>
+                      </div>
+                      <span class="help-block">Current number of storage volumes</span>
+                    </div>
 
+                    <div class="col">
+                      <div class="input-group">
+                        <input required class="form-control"
+                               id="id_project_application_renewal_volume_counter"
+                               name="project_application_renewal_volume_counter"
+                               placeholder="e.g. 20"
+                               type="number" min="0" step="1"
+                               [ngModel]="selectedApplication?.VolumeCounter"
+                               appMinAmount="0" appInteger
+                               [ngClass]="{
+                                'is-invalid': f.controls.project_application_renewal_volume_counter?.invalid,
+                                'is-valid': f.controls.project_application_renewal_volume_counter?.valid
+                                }">
+                      </div>
+                      <span class="help-block">How many storage volumes do you need in the future?</span>
+                    </div>
+                  </div>
                     <div class="form-group row">
                         <label class="col-md-4 form-control-label" for="textarea-input"><strong>Storage
                             Limit*
@@ -1276,7 +1311,8 @@
                                        [ngClass]="{
                                 'is-invalid': f.controls.project_application_renewal_volume_limit?.invalid,
                                 'is-valid': f.controls.project_application_renewal_volume_limit?.valid
-                                }">
+                                }"
+                                [disabled]="f.controls.project_application_renewal_volume_counter?.value == 0">
                                 <div class="input-group-append"><span class="input-group-text"> GB
                                     </span></div>
                             </div>
@@ -1284,42 +1320,7 @@
                         </div>
                     </div>
 
-                    <div class="form-group row">
-                        <label class="col-md-4 form-control-label" for="textarea-input"><strong>Number
-                            of storage
-                            volumes*
-                            <i data-balloon="Number of volumes allowed to create. The sum of the volumes size equals the value provided in the storage limit field."
-                               data-balloon-pos="down" data-balloon-length="large"><i
-                                    class="icon-question"
-                                    style="cursor: pointer;"></i></i></strong></label>
-                        <div class="col">
-                            <div class="input-group">
-                                <input required class="form-control"
-                                       name="project_application_volume_counter"
-                                       placeholder="NDA"
-                                       value="{{selectedApplication?.VolumeCounter}}"
-                                       type="text" disabled>
-                            </div>
-                            <span class="help-block">Current number of storage volumes</span>
-                        </div>
 
-                        <div class="col">
-                            <div class="input-group">
-                                <input required class="form-control"
-                                       id="id_project_application_renewal_volume_counter"
-                                       name="project_application_renewal_volume_counter"
-                                       placeholder="e.g. 20"
-                                       type="number" min="0" step="1"
-                                       [ngModel]="selectedApplication?.VolumeCounter"
-                                       appMinAmount="0" appInteger
-                                       [ngClass]="{
-                                'is-invalid': f.controls.project_application_renewal_volume_counter?.invalid,
-                                'is-valid': f.controls.project_application_renewal_volume_counter?.valid
-                                }">
-                            </div>
-                            <span class="help-block">How many storage volumes do you need in the future?</span>
-                        </div>
-                    </div>
 
                     <div *ngIf="selectedApplication?.OpenStackProject" class="form-group row">
                         <label class="col-md-4 form-control-label" for="textarea-input"><strong>Object

--- a/src/app/applications/applications.component.ts
+++ b/src/app/applications/applications.component.ts
@@ -317,6 +317,9 @@ export class ApplicationsComponent extends ApplicationBaseClass implements OnIni
     onSubmit(form: NgForm): void {
         const values: { [key: string]: string | number | boolean } = {};
         for (const value in form.controls) {
+            if (form.controls[value].disabled) {
+              continue;
+            }
             if (form.controls[value].value) {
                 values[value] = form.controls[value].value;
             }

--- a/src/app/shared/shared_modules/baseClass/application-base-class.ts
+++ b/src/app/shared/shared_modules/baseClass/application-base-class.ts
@@ -438,6 +438,10 @@ export class ApplicationBaseClass extends AbstractBaseClasse {
                     }
                 }
                 if (key in this.constantStrings) {
+                    if (form.controls[key].disabled) {
+                      continue;
+                    }
+
                     this.valuesToConfirm.push(this.matchString(key.toString(), form.controls[key].value.toString()));
 
                     const flavor: Flavor = this.isKeyFlavor(key.toString());


### PR DESCRIPTION
Place of Storage Limit and Number of Storage Volumes switched.
Storage Limit disabled if Number of Storage Volumes equals zero.
In add components and mod requests (in onSubmit Function) a form control is skipped if it is disabled, also filterEnteredData in application-base-class skips pushing to valuesToConfirm if a form control is disabled.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
