### PR TITLE
Fix/make and jsn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ env: is_line_in_hosts check_nodeenv .nodeenvrc # Creates an env folder if not al
 	if ! test -d env; \
 	then echo Env folder does not exist. Creating env folder.; \
 	nodeenv -C .nodeenvrc env; \
+	. env/bin/activate; \
+    echo Rebuilding node-sass; \
+    npm rebuild node-sass; \
 	elif [ $$(find env/src/ -maxdepth 1 -name "*$(NODEENVRC_VERSION)*" | wc -l) -eq 0 ]; \
 	then echo Env folder found, but node version is not the same as in the .nodeenvrc.; \
 	while [ -z "$$CONTINUE" ]; do \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ make help
 5. Start the angular server with make or by yourself
 ~~~BASH
 make serve
+~~~
 or
+~~~BASH
+. env/bin/activate
 ng serve
 ~~~
 


### PR DESCRIPTION
Npm rebuild node-sass is run everytime the env folder is created anew, when running make.
Jsnlog now batches 5 instead of 30 messages and sends them to the server.
In the readme the instructions is fixed, that . env/bin/activate should be run before running ng serve.
The Error-Handler with the jsnlog options now has some comments to clarify what is happening.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
