### PR TITLE
fix(new-instance): optional parameters not shown when ressources…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,7 +37,6 @@ import {Angulartics2Module} from 'angulartics2';
 import { ErrorHandler } from '@angular/core';
 import {UncaughtExceptionHandler} from './error-handler/UncaughtExceptionHandler.service';
 import {CookieService} from 'ngx-cookie-service';
-
 /**
  * App module.
  */
@@ -88,7 +87,7 @@ import {CookieService} from 'ngx-cookie-service';
       },
         ApiSettings,
         UserService,
-        CookieService,
+        CookieService
     ],
     bootstrap: [AppComponent]
 })

--- a/src/app/applications/applications.module.ts
+++ b/src/app/applications/applications.module.ts
@@ -10,17 +10,12 @@ import {ModalModule} from 'ngx-bootstrap/modal';
 import {AddsimplevmComponent} from './addsimplevm.component';
 import {AddcloudapplicationComponent} from './addcloudapplication.component';
 import {ClickOutsideModule} from 'ng4-click-outside';
-import {
-  MinAmoutValidatorDirective,
-  MaxAmoutValidatorDirective,
-  IntegerValidatorDirective,
-  IntegerOrNullValidatorDirective
-} from './numberValidations.directive';
 import {TypeOverviewComponent} from './type-overview.component';
 import {AppSidebarModule} from '@coreui/angular';
 import {ValidationApplicationComponent} from '../validation-application/validation-application.component';
 import {AutocompleteLibModule} from 'angular-ng-autocomplete';
 import {ApplicationDetailComponent} from './application-detail/application-detail.component';
+import {SharedDirectivesModule} from '../shared/shared_modules/shared_directives.module';
 
 /**
  * Applications Module.
@@ -35,16 +30,13 @@ import {ApplicationDetailComponent} from './application-detail/application-detai
               FormsModule,
               ModalModule.forRoot(),
               AppSidebarModule,
-              AutocompleteLibModule
+              AutocompleteLibModule,
+              SharedDirectivesModule
             ],
             declarations: [
               ApplicationsComponent,
               AddsimplevmComponent,
               AddcloudapplicationComponent,
-              MinAmoutValidatorDirective,
-              MaxAmoutValidatorDirective,
-              IntegerValidatorDirective,
-              IntegerOrNullValidatorDirective,
               TypeOverviewComponent,
               ValidationApplicationComponent,
               ApplicationDetailComponent

--- a/src/app/shared/shared_modules/shared_directives.module.ts
+++ b/src/app/shared/shared_modules/shared_directives.module.ts
@@ -1,0 +1,27 @@
+import {
+  MinAmoutValidatorDirective,
+  MaxAmoutValidatorDirective,
+  IntegerValidatorDirective,
+  IntegerOrNullValidatorDirective
+} from '../../applications/numberValidations.directive';
+import {NgModule} from '@angular/core';
+
+@NgModule({
+  imports: [],
+  declarations: [
+    MinAmoutValidatorDirective,
+    MaxAmoutValidatorDirective,
+    IntegerValidatorDirective,
+    IntegerOrNullValidatorDirective
+  ],
+  exports: [
+    MinAmoutValidatorDirective,
+    MaxAmoutValidatorDirective,
+    IntegerValidatorDirective,
+    IntegerOrNullValidatorDirective
+  ]
+          })
+
+export class SharedDirectivesModule {
+
+}

--- a/src/app/virtualmachines/addvm.component.html
+++ b/src/app/virtualmachines/addvm.component.html
@@ -256,11 +256,11 @@
                   <div
                     *ngIf="selectedProjectVolumesUsed < selectedProjectVolumesMax && selectedProjectVmsUsed < selectedProjectVmsMax">
                     <div class="form-group row" *ngIf="selectedProject && selectedProject[1] != FREEMIUM_ID">
-                      <label *ngIf="diskspace <= 0" class="col-md-2 form-control-label">Volume name</label>
-                      <label *ngIf="diskspace > 0 " class="col-md-2 form-control-label"><strong>Volume
+                      <label *ngIf="diskspace <= 0" class="col-md col-sm col-lg-2 col-xl-2 form-control-label">Volume name</label>
+                      <label *ngIf="diskspace > 0 " class="col-md col-sm col-lg-2 col-xl-2 form-control-label"><strong>Volume
                         name*</strong></label>
 
-                      <div class="col-6">
+                      <div class="col-xl-6 col-sm-12 col-md-8">
                         <input type="text" placeholder="Volume name"
                                [value]="volumeName"
                                (input)="volumeName = $event.target.value"
@@ -275,11 +275,11 @@
 
                     class="form-group row">
 
-                    <label class="col-2 form-control-label">Storage</label>
+                    <label class="col-lg-2 col-sm form-control-label">Storage</label>
 
-                    <div class="col-6">
+                    <div class="col-xl-6 col-md-8 col-sm-12">
                       <div class="row">
-                        <div class="input-group col-10" style="width: 100%">
+                        <div class="input-group col-lg-10 text-lg-right col-sm-12" style="width: 100%">
                           <input min="0" step="1" [value]="diskspace"
                                  style="height: auto"
                                  id="id_vm_volume_storage" name="vm_volume_storage"
@@ -297,9 +297,9 @@
                                     </span></div>
                         </div>
 
-                        <div class="col-2" style="text-align:right;">
+                        <div class="col-lg-2 text-lg-right col-sm-12 text-sm-left">
                           <p><strong
-                            style="position: relative;top: 8px; text-align: right;"> {{selectedProjectDiskspaceMax - selectedProjectDiskspaceUsed}}
+                            style="position: relative;top: 8px"> {{selectedProjectDiskspaceMax - selectedProjectDiskspaceUsed}}
                             GB available
                           </strong></p>
                         </div>

--- a/src/app/virtualmachines/addvm.component.html
+++ b/src/app/virtualmachines/addvm.component.html
@@ -232,7 +232,7 @@
               </div>
               <accordion class="col-md-12">
                 <accordion-group #optionalGroup
-                                 *ngIf="selectedProject && selectedProject[1] != FREEMIUM_ID && selectedProjectVmsUsed < selectedProjectVmsMax">
+                                 *ngIf="selectedProject && selectedProject[1] != FREEMIUM_ID && selectedProjectVmsUsed < selectedProjectVmsMax && flavors.length != 0">
                   <div accordion-heading style="width: 100%; cursor: pointer">
                     <strong>Optional parameters</strong>
                     <i class="pull-right float-right" style="font-size: 25px" [ngClass]="{
@@ -260,7 +260,7 @@
                       <label *ngIf="diskspace > 0 " class="col-md-2 form-control-label"><strong>Volume
                         name*</strong></label>
 
-                      <div class="col-md-6">
+                      <div class="col-6">
                         <input type="text" placeholder="Volume name"
                                [value]="volumeName"
                                (input)="volumeName = $event.target.value"
@@ -275,25 +275,34 @@
 
                     class="form-group row">
 
-                    <label class="col-md-2 form-control-label">Storage</label>
+                    <label class="col-2 form-control-label">Storage</label>
 
                     <div class="col-6">
-                      <div class="input-group mb-6" style="width:100%;">
-                        <input style="width: calc(100% - 160px);" min="0" step="1" [value]="diskspace"
-                               (input)="diskspace = $event.target.value"
-                               type="number" [max]="selectedProjectDiskspaceMax - selectedProjectDiskspaceUsed"
-                               placeholder="e.g 8">
-                        <div class="input-group-append"><span
-                          class="input-group-text"> GB
+                      <div class="row">
+                        <div class="input-group col-10" style="width: 100%">
+                          <input min="0" step="1" [value]="diskspace"
+                                 style="height: auto"
+                                 id="id_vm_volume_storage" name="vm_volume_storage"
+                                 class="form-control"
+                                 (input)="diskspace = $event.target.value"
+                                 type="number" [max]="selectedProjectDiskspaceMax - selectedProjectDiskspaceUsed"
+                                 placeholder="e.g 8" ngModel
+                                 appMinAmount="0" appMaxAmount="{{selectedProjectDiskspaceMax - selectedProjectDiskspaceUsed}}" appIntegerOrNull
+                                 [ngClass]="{
+                                'is-invalid': f.controls.vm_volume_storage?.invalid && (f.controls.vm_volume_storage?.dirty || f.controls.vm_volume_storage?.touched),
+                                'is-valid': f.controls.vm_volume_storage?.valid && (f.controls.vm_volume_storage?.dirty || f.controls.vm_volume_storage?.touched)
+                                }">
+                          <div class="input-group-append" style="height: auto"><span
+                            class="input-group-text"> GB
                                     </span></div>
+                        </div>
 
-                        <div style="width:115px; text-align:right">
+                        <div class="col-2" style="text-align:right;">
                           <p><strong
                             style="position: relative;top: 8px; text-align: right;"> {{selectedProjectDiskspaceMax - selectedProjectDiskspaceUsed}}
                             GB available
                           </strong></p>
                         </div>
-
                       </div>
                     </div>
 
@@ -326,7 +335,7 @@
 
 
                 <accordion-group #autoGroup
-                                 *ngIf="selectedProject && projectDataLoaded && selectedProjectVmsUsed < selectedProjectVmsMax">
+                                 *ngIf="selectedProject && projectDataLoaded && selectedProjectVmsUsed < selectedProjectVmsMax && flavors.length != 0">
                   <div accordion-heading style="width: 100%; cursor: pointer">
                     <strong>Tools </strong> powered by <img src="{{bioconda_img_path}}" alt="Bioconda® "
                                                             style="height: 12px; width: auto"><span

--- a/src/app/virtualmachines/vm.module.ts
+++ b/src/app/virtualmachines/vm.module.ts
@@ -19,6 +19,7 @@ import {AccordionModule, BsDropdownModule} from 'ngx-bootstrap';
 import {BiocondaComponent} from './conda/bioconda.component';
 import {HowToConnectComponent} from './shared-modal/how-to-connect.component';
 import {PopoverModule} from 'ngx-smart-popover';
+import {SharedDirectivesModule} from '../shared/shared_modules/shared_directives.module';
 
 /**
  * VM module.
@@ -36,7 +37,8 @@ import {PopoverModule} from 'ngx-smart-popover';
               BsDropdownModule.forRoot(),
               CarouselModule,
               AccordionModule.forRoot(),
-              PopoverModule
+              PopoverModule,
+              SharedDirectivesModule
 
             ],
             declarations: [


### PR DESCRIPTION
@vktrrdk 
The accordion groups optional parameters and bioconda should not be visible anymore if no resources are left. (e.g. check by creating a simplevm project requesting 4 default vm but start a small one)
In optional parameters the storage row should stay at one line at each screen size

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

