### PR TITLE
fix(vm-overview): popover arrow aligned, popup on mouseenter, close on mouseenter and clickoutside

### DIFF
--- a/src/app/virtualmachines/vm.module.ts
+++ b/src/app/virtualmachines/vm.module.ts
@@ -18,8 +18,8 @@ import {ClickOutsideModule} from 'ng4-click-outside';
 import {AccordionModule, BsDropdownModule} from 'ngx-bootstrap';
 import {BiocondaComponent} from './conda/bioconda.component';
 import {HowToConnectComponent} from './shared-modal/how-to-connect.component';
-import {PopoverModule} from 'ngx-smart-popover';
 import {SharedDirectivesModule} from '../shared/shared_modules/shared_directives.module';
+import {PopoverModule} from 'ngx-bootstrap/popover';
 
 /**
  * VM module.
@@ -37,8 +37,8 @@ import {SharedDirectivesModule} from '../shared/shared_modules/shared_directives
               BsDropdownModule.forRoot(),
               CarouselModule,
               AccordionModule.forRoot(),
-              PopoverModule,
-              SharedDirectivesModule
+              SharedDirectivesModule,
+              PopoverModule.forRoot()
 
             ],
             declarations: [

--- a/src/app/virtualmachines/vmOverview.component.html
+++ b/src/app/virtualmachines/vmOverview.component.html
@@ -120,19 +120,24 @@
         <tr *ngIf="!isSearching">
 
 
-          <td [popover]="namePopover">
-            <popover-content #namePopover placement="right" [title]="vm?.name" [closeOnMouseOutside]="false"
-                             [closeOnClickOutside]="true"
-            >
+          <td >
+            <ng-template #nameTablePopover>
               <table class="table-bordered">
                 <tr>
                   <td>ID</td>
                   <td>{{vm?.openstackid}}</td>
                 </tr>
               </table>
-            </popover-content>
+            </ng-template>
 
-            <strong style="color: #005AA9;">{{vm?.name}}            </strong>
+            <strong style="color: #005AA9;"
+                    [popover]="nameTablePopover"
+                    placement="right"
+                    triggers="mouseenter"
+                    [outsideClick]="true"
+                    [popoverTitle]="vm?.name">
+              {{vm?.name}}
+            </strong>
 
 
           </td>
@@ -141,13 +146,8 @@
           <td style="word-wrap: break-word;min-width: 110px; max-width: 110px; white-space: normal">
             {{vm.project}}
           </td>
-          <td [popover]="flavorPopover">
-            <popover-content #flavorPopover
-                             [title]="vm?.flavor?.name"
-                             placement="right"
-                             [animation]="true"
-                             [closeOnClickOutside]="false"
-                             [closeOnMouseOutside]="false">
+          <td >
+            <ng-template #flavorPopover>
               <div class="scroll-flavor">
 
                 <div class="col">
@@ -185,9 +185,15 @@
                   </div>
                 </div>
               </div>
-            </popover-content>
+            </ng-template>
 
-            <strong style="color: #005AA9;">{{vm?.flavor?.name}}</strong>
+
+            <strong style="color: #005AA9;"
+                    [popover]="flavorPopover"
+                    placement="right"
+                    triggers="mouseenter"
+                    [outsideClick]="true"
+                    [popoverTitle]="vm?.flavor?.name">{{vm?.flavor?.name}}</strong>
           </td>
           <td style="word-wrap: break-word;min-width: 110px; max-width: 110px; white-space: normal">
                          <span *ngIf="vm.status == vm_statuses[vm_statuses.DELETED]"


### PR DESCRIPTION
@dweinholz 
The arrow is now aligned with the name and flavor name, opens on mouseenter and only closes on mouseenter again or on a click outside of the name. Now possible to copy from popover without a hassle.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

