### PR TITLE
Feat/resenv mode

### DIFF
--- a/src/app/api-connector/bioconda.service.ts
+++ b/src/app/api-connector/bioconda.service.ts
@@ -41,4 +41,15 @@ export class BiocondaService {
       params: params
     })
   }
+
+  getAllowedForcTemplates(facility_id?: string): Observable<any> {
+    const params: HttpParams = new HttpParams()
+      .set('facility_id', facility_id);
+
+    return this.http.get(`${ApiSettings.getApiBaseURL()}forc/templates/allowed/`, {
+      headers: header,
+      withCredentials: true,
+      params: params
+    })
+  }
 }

--- a/src/app/api-connector/bioconda.service.ts
+++ b/src/app/api-connector/bioconda.service.ts
@@ -3,6 +3,7 @@ import {ApiSettings} from './api-settings.service'
 import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {Cookie} from 'ng2-cookies/ng2-cookies';
+import {ResearchEnvironment} from '../virtualmachines/virtualmachinemodels/res-env';
 
 const header: HttpHeaders = new HttpHeaders({
                                               'X-CSRFToken': Cookie.get('csrftoken')
@@ -31,11 +32,11 @@ export class BiocondaService {
     })
   }
 
-  getForcTemplates(clientid: string): Observable<any> {
+  getForcTemplates(clientid: string): Observable<ResearchEnvironment[]> {
     const params: HttpParams = new HttpParams()
       .set('clientid', clientid);
 
-    return this.http.get(`${ApiSettings.getApiBaseURL()}forc/templates/`, {
+    return this.http.get<ResearchEnvironment[]>(`${ApiSettings.getApiBaseURL()}forc/templates/`, {
       headers: header,
       withCredentials: true,
       params: params

--- a/src/app/api-connector/virtualmachine.service.ts
+++ b/src/app/api-connector/virtualmachine.service.ts
@@ -47,8 +47,7 @@ export class VirtualmachineService {
   }
 
   startVM(flavor: string, image: Image, servername: string, project: string, projectid: string, http: boolean, https: boolean,
-          udp: boolean, volumename?: string, diskspace?: string, playbook_information?: string, resenvTags?: string,
-          user_key_url?: string): Observable<any> {
+          udp: boolean, volumename?: string, diskspace?: string, playbook_information?: string, user_key_url?: string): Observable<any> {
 
     const params: HttpParams = new HttpParams()
       .set('flavor', flavor)
@@ -62,7 +61,6 @@ export class VirtualmachineService {
       .set('https_allowed', https.toString())
       .set('udp_allowed', udp.toString())
       .set('playbook_information', playbook_information)
-      .set('resenvTags', resenvTags)
       .set('user_key_url', user_key_url);
 
     return this.http.post(this.baseVmUrl, params, {

--- a/src/app/facility_manager/image-tag.ts
+++ b/src/app/facility_manager/image-tag.ts
@@ -15,7 +15,7 @@ export interface ImageMode {
   name: string;
   description: string;
   copy_field: string;
-  virtualmachines_counter: number;
+  virtualmachines_counter?: number;
 }
 
 /**

--- a/src/app/facility_manager/imageTag.component.html
+++ b/src/app/facility_manager/imageTag.component.html
@@ -51,7 +51,13 @@
           </div>
         </div>
 
+
         <div class="card-body">
+          <div class="alert alert-info">Suggested modes:<br>
+            <ng-container *ngFor="let mode of suggestedModes">
+              {{mode}}
+            </ng-container>
+          </div>
 
           <div class="table-responsive">
             <table class="table table-striped table-bordered">

--- a/src/app/facility_manager/imageTag.component.html
+++ b/src/app/facility_manager/imageTag.component.html
@@ -140,6 +140,10 @@
                 <td class="text-center">&#123;COPY&#125;</td>
                 <td class="text-center">Inserts the text in the description from the COPY FIELD.</td>
               </tr>
+              <tr>
+                <td class="text-center">&#123;RESENV_URL&#125;</td>
+                <td class="text-center">Returns the Research-Environment URL of the Virtual Machine.</td>
+              </tr>
               </tbody>
             </table>
           </div>

--- a/src/app/facility_manager/imagetags.component.ts
+++ b/src/app/facility_manager/imagetags.component.ts
@@ -3,6 +3,7 @@ import {Component, OnInit} from '@angular/core';
 import {BlockedImageTag, ImageLogo, ImageMode, ImageTag} from './image-tag';
 import {forkJoin} from 'rxjs';
 import {FacilityService} from '../api-connector/facility.service';
+import {BiocondaService} from '../api-connector/bioconda.service';
 
 /**
  * ImageTag component.
@@ -10,7 +11,7 @@ import {FacilityService} from '../api-connector/facility.service';
 @Component({
              selector: 'app-image-tags',
              templateUrl: 'imageTag.component.html',
-             providers: [ImageService, FacilityService]
+             providers: [ImageService, FacilityService, BiocondaService]
            })
 export class ImageTagComponent implements OnInit {
 
@@ -28,6 +29,7 @@ export class ImageTagComponent implements OnInit {
   imageUrl: string;
   show_html: boolean = false;
   selectedMode: ImageMode;
+  suggestedModes: string[] = [];
 
   /**
    * Facilitties where the user is manager ['name',id].
@@ -38,7 +40,7 @@ export class ImageTagComponent implements OnInit {
    */
   public selectedFacility: [string, number];
 
-  constructor(private imageService: ImageService, private facilityService: FacilityService) {
+  constructor(private imageService: ImageService, private facilityService: FacilityService, private biocondaService: BiocondaService) {
 
   }
 
@@ -57,6 +59,7 @@ export class ImageTagComponent implements OnInit {
     this.facilityService.getManagerFacilities().subscribe((result: any) => {
       this.managerFacilities = result;
       this.selectedFacility = this.managerFacilities[0];
+      this.getTagModeSuggestions();
       forkJoin(
         this.imageService.getImageTags(this.selectedFacility['FacilityId']),
         this.imageService.getImageLogos(),
@@ -99,8 +102,7 @@ export class ImageTagComponent implements OnInit {
     if (input.validity.valid) {
       this.imageService.addImageTags(tag.trim(), this.checkedModes, this.selectedFacility['FacilityId']).subscribe((newTag: ImageTag) => {
         this.checkedModes = [];
-        this.imageTags.push(newTag)
-
+        this.imageTags.push(newTag);
       });
       this.alertRed = false;
     } else {
@@ -111,8 +113,8 @@ export class ImageTagComponent implements OnInit {
   addImageMode(name: string, description: string, copy_field: string): void {
     const newMode: ImageMode = {name: name, description: description, copy_field: copy_field};
     this.imageService.addImageMode(newMode, this.selectedFacility['FacilityId']).subscribe((createdMode: ImageMode) => {
-      this.imageModes.push(createdMode)
-
+      this.imageModes.push(createdMode);
+      this.getTagModeSuggestions();
     });
 
   }
@@ -133,7 +135,7 @@ export class ImageTagComponent implements OnInit {
     update_mode.name = name;
     this.imageService.updateImageMode(update_mode).subscribe((updated_mode: ImageMode) => {
       this.imageModes[idx] = updated_mode;
-
+      this.getTagModeSuggestions();
     })
   }
 
@@ -162,6 +164,14 @@ export class ImageTagComponent implements OnInit {
         this.blockedImageTags = tags;
       })
     })
+  }
+
+  getTagModeSuggestions(): void {
+    this.biocondaService
+      .getAllowedForcTemplates(this.selectedFacility['FacilityId'].toString())
+      .subscribe((response: any[]) => {
+        this.suggestedModes = response.map((template: any) => template['name']);
+      });
   }
 
 }

--- a/src/app/facility_manager/imagetags.component.ts
+++ b/src/app/facility_manager/imagetags.component.ts
@@ -142,7 +142,7 @@ export class ImageTagComponent implements OnInit {
     const idx: number = this.imageModes.indexOf(this.selectedMode);
     const update_mode: ImageMode = Object.assign({}, this.selectedMode);
     update_mode.description = this.updateModeDescription;
-    update_mode.copy_field = this.updateModeDescription;
+    update_mode.copy_field = this.updateModeCopy;
     update_mode.name = this.updateModeName;
     this.imageService.updateImageMode(update_mode).subscribe((updated_mode: ImageMode) => {
       this.imageModes[idx] = updated_mode;

--- a/src/app/virtualmachines/addvm.component.html
+++ b/src/app/virtualmachines/addvm.component.html
@@ -338,9 +338,19 @@
         </div>
 
         <div
-          *ngIf="((!vm_name || (!gaveOkay && hasTools) || !selectedImage || (!selectedFlavor && flavors.length != 0 ) || (diskspace > 0 && !volumeName))) && flavors.length > 0 && projectDataLoaded  && flavors_loaded  && (selectedProjectVmsUsed < selectedProjectVmsMax)"
+          *ngIf="
+          ( !vm_name
+            || (!gaveOkay && hasTools)
+            || !resEnvValid
+            || !selectedImage
+            || (!selectedFlavor && flavors.length != 0 )
+            || (diskspace > 0 && !volumeName) )
+          && flavors.length > 0
+          && projectDataLoaded
+          && flavors_loaded
+          && (selectedProjectVmsUsed < selectedProjectVmsMax)"
           class="alert alert-danger" role="alert" style="max-width: 600px;margin: 0 auto;">
-          <p>Please choose the following before starting a VM:</p>
+          <p>The following is missing before starting a VM:</p>
           <p *ngIf="!vm_name">- A name for your instance
           </p>
           <p *ngIf="!selectedFlavor">- The flavor type of your VM
@@ -350,6 +360,10 @@
           <p *ngIf="diskspace > 0 && !volumeName">- A name for your storage volume
           </p>
           <p *ngIf="!gaveOkay && hasTools">- Give your okay to the Bioconda install process
+          </p>
+          <p *ngIf="resEnvNeedsName">- An url name for your Research-Environment
+          </p>
+          <p *ngIf="resEnvNeedsTemplate">- A Research-Environment template
           </p>
 
         </div>
@@ -367,7 +381,8 @@
                   !selectedFlavor ||
                   !selectedImage||
                   (diskspace > 0 && volumeName == '') ||
-                  (!gaveOkay && hasTools)"
+                  (!gaveOkay && hasTools) ||
+                  !resEnvValid"
                   class="btn btn-primary  .btn-lg offset-md-8"
                   data-toggle="modal"
                   (click)="startVM(selectedFlavor.name,f.controls.instance_name.value,selectedProject[0],selectedProject[1]);resetData();resetProgressBar;infoModal.show();">

--- a/src/app/virtualmachines/addvm.component.html
+++ b/src/app/virtualmachines/addvm.component.html
@@ -327,13 +327,9 @@
                     <i class="pull-right float-right" style="font-size: 25px" [ngClass]="{
                             'icon-arrow-up': resEnvGroup.isOpen, 'icon-arrow-down': !resEnvGroup.isOpen}"></i>
                   </div>
-                  <app-res-env *ngIf="selectedImage !== undefined && selectedImage.tags.indexOf('resenv') != -1"
-                               #resEnv
+                  <app-res-env #resEnv
                                [clientid]="client_id"
-                               [onlyNamespace]="true"></app-res-env>
-                  <app-res-env *ngIf="selectedImage === undefined || selectedImage?.tags.indexOf('resenv') == -1"
-                               #resEnv
-                               [clientid]="client_id"></app-res-env>
+                               [onlyNamespace]="resenvSelected"></app-res-env>
                 </accordion-group>
               </accordion>
             </div>

--- a/src/app/virtualmachines/addvm.component.ts
+++ b/src/app/virtualmachines/addvm.component.ts
@@ -20,6 +20,7 @@ import {UserService} from '../api-connector/user.service';
 import {BiocondaComponent} from './conda/bioconda.component';
 import {ResEnvComponent} from './conda/res-env.component';
 import {is_vo} from '../shared/globalvar';
+import {TemplateNames} from './conda/template-names';
 
 /**
  * Start virtualmachine component.
@@ -66,6 +67,7 @@ export class VirtualMachineComponent implements OnInit {
   has_forc: boolean = false;
   client_id: string;
   mosh_mode_available: boolean = false;
+  resenvSelected: boolean = false;
 
   title: string = 'New Instance';
 
@@ -330,21 +332,21 @@ export class VirtualMachineComponent implements OnInit {
       } else {
         this.progress_bar_width = this.THIRTY_THIRD_PERCENT;
       }
-      const play_information: string = this.getPlaybookInformation();
+      let play_information: string = this.getPlaybookInformation();
       if (play_information !== '{}') {
         this.playbook_run = 1;
+      } else {
+        play_information = null;
       }
-      let tags: string = null;
       let user_key_url: string = null;
-      if (this.selectedImage.tags.indexOf('resenv') !== -1) {
-        tags = this.selectedImage.tags.toString();
+      if (this.resenvSelected) {
         user_key_url = this.resEnvComponent.getUserKeyUrl();
       }
       this.virtualmachineservice.startVM(
         flavor_fixed, this.selectedImage, servername,
         project, projectid.toString(), this.http_allowed,
         this.https_allowed, this.udp_allowed, this.volumeName,
-        this.diskspace.toString(), play_information, tags, user_key_url)
+        this.diskspace.toString(), play_information, user_key_url)
         .subscribe((newVm: VirtualMachine) => {
           this.started_machine = false;
 
@@ -504,7 +506,8 @@ export class VirtualMachineComponent implements OnInit {
   setSelectedImage(image: Image): void {
 
     this.selectedImage = image;
-    this.isMoshModeAvailable()
+    this.isMoshModeAvailable();
+    this.hasImageResenv();
 
   }
 
@@ -521,6 +524,17 @@ export class VirtualMachineComponent implements OnInit {
 
     return
 
+  }
+
+  hasImageResenv(): void {
+    for (const mode of this.selectedImage.modes) {
+      if (TemplateNames.ALL_TEMPLATE_NAMES.indexOf(mode.name) !== -1) {
+        this.resenvSelected = true;
+
+        return;
+      }
+    }
+    this.resenvSelected = false;
   }
 
   setSelectedFlavor(flavor: Flavor): void {

--- a/src/app/virtualmachines/conda/res-env.component.html
+++ b/src/app/virtualmachines/conda/res-env.component.html
@@ -19,8 +19,8 @@
     <div *ngIf="selectedTemplate.template_name !== 'undefined'" class="col">
       <div class="card border-success flavor-image-card" style="cursor: default;">
         <div class="card-header bg-success text-truncate" data-toggle="tooltip" data-placement="top"
-             title="{{selectedTemplate.template_title}}" (click)="setSelectedTemplate(null)" style="cursor: pointer;">
-          <strong>{{selectedTemplate.template_title}}</strong>
+             title="{{selectedTemplate.title}}" (click)="setSelectedTemplate(null)" style="cursor: pointer;">
+          <strong>{{selectedTemplate.title}}</strong>
           <button type="button" class="close"
                   aria-label="Close">
             <span aria-hidden="true">&times;</span>
@@ -28,14 +28,14 @@
         <div class="card-body">
           <div class="scroll-image">
             <p>
-              <img src="{{selectedTemplate?.template_logo_url}}" alt="{{selectedTemplate.template_title}}® "
+              <img src="{{selectedTemplate?.logo_url}}" alt="{{selectedTemplate.title}}® "
                    style="width: 70px;">
             </p>
             <p>
-              {{selectedTemplate?.template_description}}
+              {{selectedTemplate?.description}}
             </p>
-            <p *ngIf="selectedTemplate.template_info_url">
-              <a href="{{selectedTemplate?.template_info_url}}" target="_blank">Click here for more Information.</a>
+            <p *ngIf="selectedTemplate.info_url">
+              <a href="{{selectedTemplate?.info_url}}" target="_blank">Click here for more Information.</a>
             </p>
           </div>
         </div>
@@ -64,9 +64,9 @@
         <div class="card flavor-image-card" id="id_template_owl_{{template.template_name}}" style="cursor: default;">
           <div (click)="setSelectedTemplate(template)"
                class="card-header bg-info-flavor text-truncate" data-toggle="tooltip" data-placement="top"
-               title="{{template.template_title}}"
+               title="{{template.title}}"
                style="background-color: #005AA9 !important; color: white !important; cursor: pointer"> <!-- quickfix -->
-            <strong>{{template.template_title}}</strong>
+            <strong>{{template.title}}</strong>
             <button type="button" class="close"
                     aria-label="Close">
               <span aria-hidden="true">+</span>
@@ -74,13 +74,13 @@
           <div class="card-body">
             <div class="scroll-image">
               <p>
-                <img src="{{template?.template_logo_url}}" alt="{{template.template_title}}® " style="width: 70px;">
+                <img src="{{template?.logo_url}}" alt="{{template.title}}® " style="width: 70px;">
               </p>
               <p>
-                {{template?.template_description}}
+                {{template?.description}}
               </p>
-              <p *ngIf="template.template_info_url">
-                <a href="{{template?.template_info_url}}" target="_blank">Click here for more Information.</a>
+              <p *ngIf="template.info_url">
+                <a href="{{template?.info_url}}" target="_blank">Click here for more Information.</a>
               </p>
             </div>
           </div>

--- a/src/app/virtualmachines/conda/res-env.component.ts
+++ b/src/app/virtualmachines/conda/res-env.component.ts
@@ -44,36 +44,44 @@ export class ResEnvComponent implements OnInit {
   ngOnInit(): void {
     this.undefinedTemplate.template_name = 'undefined';
     this.setSelectedTemplate(null);
-    this.condaService.getForcTemplates(this.clientid).subscribe((templates: any) => {
-      for (const dict of templates) {
-        const resenv: ResearchEnvironment = new ResearchEnvironment();
-        resenv.template_name = dict['name'];
-        resenv.template_version = dict['version'];
-        switch (resenv.template_name) {
-          case 'rstudio':
-            resenv.template_logo_url = `static/webapp/assets/img/RStudio-Logo-flat.svg`;
-            resenv.template_description = 'RStudio is an integrated development environment (IDE) for R. ' +
-              'It includes a console, syntax-highlighting editor that supports direct code execution, ' +
-              'as well as tools for plotting, history, ' +
-              'debugging and workspace management.';
-            resenv.template_info_url = 'https://rstudio.com/products/rstudio/features/';
-            resenv.template_title = 'RStudio';
-            break;
-          case 'theiaide':
-            resenv.template_title = 'Theia';
-            break;
-          case 'guacamole':
-            resenv.template_title = 'Guacamole';
-            break;
-          case 'jupyternotebook':
-            resenv.template_title = 'Jupyter Notebook';
-            break;
-          default:
-            resenv.template_title = resenv.template_name;
-            break;
-        }
-        this.templates.push(resenv);
-      }
+    this.condaService.getForcTemplates(this.clientid).subscribe((templates: ResearchEnvironment[]) => {
+      this.templates = templates;
     });
+  }
+
+  isValid(): boolean {
+    if (this.onlyNamespace) {
+
+      return this.user_key_url.errors === null;
+    } else {
+      if (this.selectedTemplate.template_name === 'undefined') {
+
+        return this.user_key_url.value.length === 0;
+      } else {
+
+        return this.user_key_url.errors === null;
+      }
+    }
+  }
+
+  needsName(): boolean {
+    if (this.onlyNamespace || this.selectedTemplate.template_name !== 'undefined') {
+      return this.user_key_url.errors !== null;
+    }
+  }
+
+  needsTemplate(): boolean {
+    if (this.user_key_url.value.length !== 0 && !this.onlyNamespace) {
+      return this.selectedTemplate.template_name === 'undefined';
+    }
+  }
+
+  setOnlyNamespace(): void {
+    this.onlyNamespace = true;
+    this.setSelectedTemplate(null);
+  }
+
+  unsetOnlyNamespace(): void {
+    this.onlyNamespace = false;
   }
 }

--- a/src/app/virtualmachines/conda/template-names.ts
+++ b/src/app/virtualmachines/conda/template-names.ts
@@ -1,0 +1,48 @@
+export class TemplateNames {
+  private static _RSTUDIO: string = 'rstudio';
+  private static _THEIA: string = 'theiaide';
+  private static _GUACAMOLE: string = 'guacamole';
+  private static _JUPYTERNOTEBOOK: string = 'jupyternotebook';
+
+  private static _ALL_TEMPLATES: string[] =
+    [TemplateNames._RSTUDIO,
+      TemplateNames._THEIA,
+      TemplateNames._GUACAMOLE,
+      TemplateNames._JUPYTERNOTEBOOK];
+
+  static get RSTUDIO(): string {
+    return this._RSTUDIO;
+  }
+
+  static set RSTUDIO(value: string) {
+    this._RSTUDIO = value;
+  }
+
+  static get THEIA(): string {
+    return this._THEIA;
+  }
+
+  static set THEIA(value: string) {
+    this._THEIA = value;
+  }
+
+  static get GUACAMOLE(): string {
+    return this._GUACAMOLE;
+  }
+
+  static set GUACAMOLE(value: string) {
+    this._GUACAMOLE = value;
+  }
+
+  static get JUPYTERNOTEBOOK(): string {
+    return this._JUPYTERNOTEBOOK;
+  }
+
+  static set JUPYTERNOTEBOOK(value: string) {
+    this._JUPYTERNOTEBOOK = value;
+  }
+
+  static get ALL_TEMPLATE_NAMES(): string [] {
+    return this._ALL_TEMPLATES;
+  }
+}

--- a/src/app/virtualmachines/shared-modal/how-to-connect.component.html
+++ b/src/app/virtualmachines/shared-modal/how-to-connect.component.html
@@ -34,11 +34,11 @@
 
     </ng-template>
   </ngb-tab>
-  <ngb-tab *ngIf="location_url != '/'">
+  <ngb-tab *ngIf="location_url != '' && resenv_by_play">
     <ng-template ngbTabTitle><b>Res-Env</b></ng-template>
     <ng-template ngbTabContent>
       <div class="row justify-content-center">
-    {{location_url}}
+    {{forc_url}}{{location_url}}/
       </div>
     </ng-template>
   </ngb-tab>

--- a/src/app/virtualmachines/shared-modal/how-to-connect.component.ts
+++ b/src/app/virtualmachines/shared-modal/how-to-connect.component.ts
@@ -3,6 +3,7 @@ import {VirtualMachine} from '../virtualmachinemodels/virtualmachine';
 import * as JSPDF from 'jspdf';
 import {VirtualmachineService} from '../../api-connector/virtualmachine.service';
 import {GroupService} from '../../api-connector/group.service';
+import {TemplateNames} from '../conda/template-names';
 
 /**
  * How to Connect moda body.
@@ -24,6 +25,8 @@ export class HowToConnectComponent implements OnChanges, OnInit {
   doc: JSPDF;
 
   forc_url: string = '';
+
+  resenv_by_play: boolean = true;
 
   constructor(private virtualMachineService: VirtualmachineService, private groupService: GroupService) {
   }
@@ -113,8 +116,13 @@ export class HowToConnectComponent implements OnChanges, OnInit {
         });
       this.virtualMachineService.getLocationUrl(current.openstackid)
         .subscribe((url: any) => {
-          this.location_url = `${this.forc_url}${url}/`;
+          this.location_url = url;
         });
+    }
+    for (const mode of current.modes) {
+      if (TemplateNames.ALL_TEMPLATE_NAMES.indexOf(mode.name) !== -1) {
+        this.resenv_by_play = false;
+      }
     }
   }
 

--- a/src/app/virtualmachines/virtualmachinemodels/res-env.ts
+++ b/src/app/virtualmachines/virtualmachinemodels/res-env.ts
@@ -4,25 +4,25 @@
 export class ResearchEnvironment {
   private _template_name: string;
   private _template_version: string;
-  private _template_description: string;
-  private _template_logo_url: string;
-  private _template_info_url: string;
-  private _template_title: string;
+  private _description: string;
+  private _logo_url: string;
+  private _info_url: string;
+  private _title: string;
 
-  get template_title(): string {
-    return this._template_title;
+  get title(): string {
+    return this._title;
   }
 
-  set template_title(value: string) {
-    this._template_title = value;
+  set title(value: string) {
+    this._title = value;
   }
 
-  get template_info_url(): string {
-    return this._template_info_url;
+  get info_url(): string {
+    return this._info_url;
   }
 
-  set template_info_url(value: string) {
-    this._template_info_url = value;
+  set info_url(value: string) {
+    this._info_url = value;
   }
 
   get template_name(): string {
@@ -41,18 +41,18 @@ export class ResearchEnvironment {
     this._template_version = value;
   }
 
-  get template_description(): string {
-    return this._template_description;
+  get description(): string {
+    return this._description;
   }
 
-  set template_description(value: string) {
-    this._template_description = value;
+  set description(value: string) {
+    this._description = value;
   }
 
-  get template_logo_url(): string {
-    return this._template_logo_url;
+  get logo_url(): string {
+    return this._logo_url;
   }
-  set template_logo_url(value: string) {
-    this._template_logo_url = value;
+  set logo_url(value: string) {
+    this._logo_url = value;
   }
 }

--- a/src/app/virtualmachines/vmOverview.component.html
+++ b/src/app/virtualmachines/vmOverview.component.html
@@ -269,12 +269,12 @@
                 </div>
 
 
-                <div class="row" *ngIf="vm?.res_env_url != '' && vm?.res_env_url != null && vm?.res_env_url != undefined">
+                <div class="row" *ngIf="vm?.res_env_url != '' && vm?.res_env_url != null && vm?.res_env_url != undefined && resenv_by_play(vm)">
                   <div class="col-md-1">
                     <span class="font-weight-bold font-xs btn-block text-muted">Res-Env:</span>
                   </div>
                   <div class="col-md-11">
-                    <a class="font-weight-bold font-xs btn-block text-muted" href="{{vm?.res_env_url}} | async" target="_blank">{{vm?.res_env_url}}</a></div>
+                    <a class="font-weight-bold font-xs btn-block text-muted" href="{{vm?.res_env_url}}" target="_blank">{{vm?.res_env_url}}</a></div>
                 </div>
               </div>
 

--- a/src/app/virtualmachines/vmOverview.component.ts
+++ b/src/app/virtualmachines/vmOverview.component.ts
@@ -16,6 +16,7 @@ import {GroupService} from '../api-connector/group.service';
 import {environment} from '../../environments/environment';
 import {ClientService} from '../api-connector/client.service';
 import {Client} from './clients/client.model';
+import {TemplateNames} from './conda/template-names';
 
 /**
  * Vm overview componentn.
@@ -733,5 +734,15 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
         });
       });
     });
+  }
+
+  resenv_by_play(vm: VirtualMachine): boolean {
+    for (const mode of vm.modes) {
+      if (TemplateNames.ALL_TEMPLATE_NAMES.indexOf(mode.name) !== -1) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
@dweinholz 
FM gets suggestions in imagetags about possible template-modes. In Copy he can/should add {RESENV_URL}. 
When attached to an imagetag, a backend will be created for vms started with images containing that tag. (There should be a snapshot with theiaide installed, available with tag: ubuntu_theia)

Also in db -> resenv, template information can/should be added for each available template. The information is used to display the resenv-cards. template_name is the template name known by forc (e.g. theiaide, rstudio, guacamole, juypternotebook).

Also validity of resenv is now checked and start button disabled if invalid name etc.

Needs:
https://github.com/deNBI/cloud-api/pull/1015
https://github.com/deNBI/cloud-portal-client/pull/205

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

