### PR TITLE
fix(vm-overview): set debounce time to 2s

### DIFF
--- a/src/app/virtualmachines/vmOverview.component.ts
+++ b/src/app/virtualmachines/vmOverview.component.ts
@@ -42,6 +42,7 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
   vms_content: VirtualMachine[] = [];
   currentPage: number = 1;
   DEBOUNCE_TIME: number = 300;
+  FILTER_DEBOUNCE_TIME: number = 2000;
 
   filter_status_list: string[] = [VirtualMachineStates.ACTIVE, VirtualMachineStates.SHUTOFF];
   isSearching: boolean = true;
@@ -591,7 +592,7 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
 
     this.filterChanged
       .pipe(
-        debounceTime(this.DEBOUNCE_TIME),
+        debounceTime(this.FILTER_DEBOUNCE_TIME),
         distinctUntilChanged())
       .subscribe(() => {
         this.applyFilter();


### PR DESCRIPTION
@dweinholz 
Set debounce time for filtering in vmOverview to 2 seconds.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

