### PR TITLE
fix(facility):history applications loaded seperatly

### DIFF
--- a/src/app/facility_manager/facility.application.component.html
+++ b/src/app/facility_manager/facility.application.component.html
@@ -245,7 +245,10 @@
     <div class="card-header">
       <i class="fa fa-align-justify"></i> Application history
     </div>
-    <div class="card-body" *ngIf="applications_history.length == 0">
+      <div *ngIf="!isHistoryLoaded" id="search_spinner" style="margin:10px; padding:10px;">
+        <div class="spinner-border text-primary" style="display:block; margin:auto;"></div>
+      </div>
+    <div class="card-body" *ngIf="applications_history.length == 0 && isHistoryLoaded">
       <div class="alert alert-warning" role="alert">
         <strong>No Applications!</strong> There are no
         applications at all!

--- a/src/app/facility_manager/facility.application.component.ts
+++ b/src/app/facility_manager/facility.application.component.ts
@@ -43,6 +43,7 @@ export class FacilityApplicationComponent extends ApplicationBaseClassComponent 
    * @type {Array}
    */
   all_application_modifications: Application [] = [];
+  isHistoryLoaded:boolean=false;
 
   applications_history: Application [] = [];
 
@@ -100,25 +101,22 @@ export class FacilityApplicationComponent extends ApplicationBaseClassComponent 
     // todo check if user is VO Admin
     this.facilityService.getFacilityApplicationsHistory(facility).subscribe((res: any) => {
       if (Object.keys(res).length === 0) {
-        this.isLoaded = true;
+        this.isHistoryLoaded = true;
       }
       const newApps: Application [] = this.setNewApplications(res);
-      this.applications_history.push.apply(this.applications_history, newApps);
-      this.isLoaded = true;
+      this.applications_history=newApps;
+      this.isHistoryLoaded = true;
     });
   }
 
   getFullApplications(facility: number): void {
     forkJoin(this.facilityService.getFacilityApplicationsWaitingForConfirmation(facility),
-             this.facilityService.getFacilityApplicationsHistory(facility),
              this.facilityService.getFacilityModificationApplicationsWaitingForConfirmation(facility)).subscribe((res: any) => {
       const newAppsWFC: Application [] = this.setNewApplications(res[0]);
       this.all_applications_wfc.push.apply(this.all_applications_wfc, newAppsWFC);
-      const newAppsMod: Application [] = this.setNewApplications(res[2]);
+      const newAppsMod: Application [] = this.setNewApplications(res[1]);
       this.all_application_modifications.push.apply(this.all_application_modifications, newAppsMod);
       this.isLoaded = true;
-      const newAppsHistory: Application [] = this.setNewApplications(res[1]);
-      this.applications_history.push.apply(this.applications_history, newAppsHistory);
     })
   }
 
@@ -213,6 +211,8 @@ export class FacilityApplicationComponent extends ApplicationBaseClassComponent 
       this.facilityService.getFacilityResources(this.selectedFacility['FacilityId']).subscribe();
       this.getApplicationStatus();
       this.getFullApplications(this.selectedFacility ['FacilityId']);
+      this.getAllApplicationsHistory(this.selectedFacility ['FacilityId']);
+
     })
   }
 


### PR DESCRIPTION
@eKatchko 
FacilityApplications: History loads seperatly

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

