### PR TITLE
fix(app): volume and name not shown when max vm, fm app history loads once

### DIFF
--- a/src/app/facility_manager/facility.application.component.ts
+++ b/src/app/facility_manager/facility.application.component.ts
@@ -92,11 +92,13 @@ export class FacilityApplicationComponent extends ApplicationBaseClassComponent 
   }
 
   getFacilityApplicationById(application: Application): void {
+    if (application.Description !== undefined) {
+      return;
+    }
     const idx: number = this.applications_history.indexOf(application);
     this.facilityService.getFacilityApplicationById(this.selectedFacility ['FacilityId'], application.Id.toString())
       .subscribe((res: any) => {
-        console.log(res)
-        this.applications_history[idx] = this.setNewApplication(res)
+        this.applications_history[idx] = this.setNewApplication(res);
       })
   }
 

--- a/src/app/virtualmachines/addvm.component.html
+++ b/src/app/virtualmachines/addvm.component.html
@@ -102,7 +102,7 @@
                 Your principal investigator can request more
                 resources if necessary.
               </div>
-              <div *ngIf="selectedProject" class="form-group row col-md-12">
+              <div *ngIf="selectedProject && selectedProjectVmsUsed < selectedProjectVmsMax" class="form-group row col-md-12">
                 <label class="col-md-2 form-control-label"><strong>Name*</strong></label>
                 <div class="col-md-10">
                   <div class="input-group">
@@ -157,7 +157,11 @@
                 </div>
               </div>
 
-              <div id="volumeDiv" style="margin-bottom: 25px;">
+              <div id="volumeDiv" style="margin-bottom: 25px;"
+                   *ngIf="selectedProject
+                   && selectedProject[1] != FREEMIUM_ID
+                   && selectedProjectVmsUsed < selectedProjectVmsMax
+                   && (flavors.length != 0 || selectedFlavor)">
                 <div class="from-group row col-md-12">
                   <label class="col-md-2"><strong>Volumes</strong></label>
                   <div class="col-md-10"></div>
@@ -193,9 +197,9 @@
                 <div class="row col-md-12">
                   <div class="col-md-2"></div>
                   <div class="col-md-10"
-                       *ngIf="!(((this.selectedProjectVolumesUsed + this.volumesToMount?.length)
-                    >= this.selectedProjectVolumesMax)
-                    || ((this.selectedProjectDiskspaceUsed + this.getStorageInList()) >= this.selectedProjectDiskspaceMax))">
+                       *ngIf="!(((selectedProjectVolumesUsed + volumesToMount?.length)
+                    >= selectedProjectVolumesMax)
+                    || ((selectedProjectDiskspaceUsed + getStorageInList()) >= selectedProjectDiskspaceMax))">
                     <button class="btn btn-light" (click)="toggleShowAddVol();" *ngIf="showAddVol" id="openAddVolumeFormButton">
                       Add Volume <span class="fa fa-plus-circle"></span>
                     </button>


### PR DESCRIPTION
@dweinholz 
ngif for name and volume in new instance
loads app detail in fm app history once by checking if description is set for app

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

