### PR TITLE
feat(vm): set for termination filter in vmoverview

### DIFF
--- a/src/app/api-connector/virtualmachine.service.ts
+++ b/src/app/api-connector/virtualmachine.service.ts
@@ -101,7 +101,8 @@ export class VirtualmachineService {
   }
 
   getAllVM(page: number, vm_per_site: number, filter?: string,
-           filter_status?: string[], filter_cluster: boolean = false): Observable<VirtualMachine[]> {
+           filter_status?: string[], filter_cluster: boolean = false,
+           filter_set_for_termination: boolean = false): Observable<VirtualMachine[]> {
     let params: HttpParams = new HttpParams().set('page', page.toString()).set('vm_per_site', vm_per_site.toString());
     if (filter) {
       params = params.append('filter', filter);
@@ -113,6 +114,10 @@ export class VirtualmachineService {
     }
     if (filter_cluster) {
       params = params.append('filter_cluster', 'true');
+
+    }
+    if (filter_set_for_termination) {
+      params = params.append('filter_set_for_termination', 'true');
 
     }
 
@@ -131,7 +136,8 @@ export class VirtualmachineService {
   }
 
   getVmsFromLoggedInUser(page: number, vm_per_site: number, filter?: string,
-                         filter_status?: string[], filter_cluster: boolean = false): Observable<VirtualMachine[]> {
+                         filter_status?: string[], filter_cluster: boolean = false,
+                         filter_set_for_termination: boolean = false): Observable<VirtualMachine[]> {
     let params: HttpParams = new HttpParams().set('page', page.toString()).set('vm_per_site', vm_per_site.toString());
 
     if (filter) {
@@ -144,6 +150,10 @@ export class VirtualmachineService {
     }
     if (filter_cluster) {
       params = params.append('filter_cluster', 'true');
+
+    }
+    if (filter_set_for_termination) {
+      params = params.append('filter_set_for_termination', 'true');
 
     }
 
@@ -171,7 +181,8 @@ export class VirtualmachineService {
   getVmsFromFacilitiesOfLoggedUser(facility_id: string | number,
                                    page: number, vm_per_site: number,
                                    filter?: string, filter_status?: string[],
-                                   filter_cluster: boolean = false): Observable<VirtualMachine[]> {
+                                   filter_cluster: boolean = false,
+                                   filter_set_for_termination: boolean = false): Observable<VirtualMachine[]> {
     let params: HttpParams = new HttpParams().set('page', page.toString()).set('vm_per_site', vm_per_site.toString());
     if (filter) {
       params = params.set('filter', filter);
@@ -183,6 +194,10 @@ export class VirtualmachineService {
     }
     if (filter_cluster) {
       params = params.append('filter_cluster', 'true');
+
+    }
+    if (filter_set_for_termination) {
+      params = params.append('filter_set_for_termination', 'true');
 
     }
 

--- a/src/app/virtualmachines/vmOverview.component.html
+++ b/src/app/virtualmachines/vmOverview.component.html
@@ -64,6 +64,11 @@
                 <span class="badge badge-info">Cluster</span>
               </div>
               <div class="input-group-text">
+                <input type="checkbox" [checked]="filter_set_for_termination" style="margin:2px;"
+                       (change)="filter_set_for_termination=!filter_set_for_termination">
+                <span class="badge badge-info">Set for termination</span>
+              </div>
+              <div class="input-group-text">
                 <input type="checkbox" checked style="margin:2px;"
                        (change)="changeFilterStatus(VirtualMachineStates.staticACTIVE)">
                 <span class="badge badge-success">{{VirtualMachineStates.staticACTIVE}}</span>

--- a/src/app/virtualmachines/vmOverview.component.ts
+++ b/src/app/virtualmachines/vmOverview.component.ts
@@ -55,6 +55,7 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
   currentPage: number = 1;
   DEBOUNCE_TIME: number = 300;
   filter_cluster: boolean = false;
+  filter_set_for_termination: boolean = false;
   filter_status_list: string[] = [VirtualMachineStates.ACTIVE, VirtualMachineStates.SHUTOFF];
   isSearching: boolean = true;
 
@@ -520,7 +521,7 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
 
     this.virtualmachineservice.getVmsFromLoggedInUser(
       this.currentPage, this.vm_per_site,
-      this.filter, this.filter_status_list, this.filter_cluster)
+      this.filter, this.filter_status_list, this.filter_cluster, this.filter_set_for_termination)
       .subscribe((vms: any) => {
                    this.prepareVMS(vms);
                  }
@@ -532,7 +533,7 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
     this.virtualmachineservice.getVmsFromFacilitiesOfLoggedUser(
       this.selectedFacility['FacilityId'],
       this.currentPage, this.vm_per_site,
-      this.filter, this.filter_status_list, this.filter_cluster)
+      this.filter, this.filter_status_list, this.filter_cluster, this.filter_set_for_termination)
       .subscribe((vms: VirtualMachine[]) => {
                    this.prepareVMS(vms);
                  }
@@ -676,7 +677,7 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
    */
   getAllVms(): void {
     this.virtualmachineservice.getAllVM(this.currentPage, this.vm_per_site,
-                                        this.filter, this.filter_status_list, this.filter_cluster)
+                                        this.filter, this.filter_status_list, this.filter_cluster, this.filter_set_for_termination)
       .subscribe((vms: VirtualMachine[]) => {
                    this.prepareVMS(vms);
                  }


### PR DESCRIPTION
@dweinholz 
On instance overview there is a set for termination filter. Just set the termination requested field in /admin/ for the vm.

needs: https://github.com/deNBI/cloud-api/pull/1510

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

