### PR TITLE
fix(facility-news): also send them to wordpress

### DIFF
--- a/src/app/api-connector/facility.service.ts
+++ b/src/app/api-connector/facility.service.ts
@@ -5,7 +5,7 @@ import {HttpClient, HttpParams} from '@angular/common/http';
 import {RamFactor} from '../facility_manager/resources/ram-factor';
 import {CoreFactor} from '../facility_manager/resources/core-factor';
 import {Application} from '../applications/application.model/application.model';
-import {WordPressTag} from "../facility_manager/newsmanagement/wp-tags";
+import {WordPressTag} from '../facility_manager/newsmanagement/wp-tags';
 
 /**
  * Service which provides methods for the facilities.

--- a/src/app/api-connector/facility.service.ts
+++ b/src/app/api-connector/facility.service.ts
@@ -5,6 +5,7 @@ import {HttpClient, HttpParams} from '@angular/common/http';
 import {RamFactor} from '../facility_manager/resources/ram-factor';
 import {CoreFactor} from '../facility_manager/resources/core-factor';
 import {Application} from '../applications/application.model/application.model';
+import {WordPressTag} from "../facility_manager/newsmanagement/wp-tags";
 
 /**
  * Service which provides methods for the facilities.
@@ -364,7 +365,7 @@ export class FacilityService {
    * @returns {Observable<any>}
    */
   sendMailToFacility(facility: string, subject: string, message: string, project_type: string,
-                     reply?: string, sendNews?: any, alternative_news_text?: string, news_tags?: string): Observable<any> {
+                     reply?: string, sendNews?: any, alternative_news_text?: string, tags?: string): Observable<any> {
     const params: HttpParams = new HttpParams()
       .set('subject', subject)
       .set('facility_id', facility)
@@ -373,7 +374,7 @@ export class FacilityService {
       .set('type', project_type)
       .set('sendNews', sendNews)
       .set('alternative_message', alternative_news_text)
-      .set('additional_tags', news_tags);
+      .set('tags', tags);
 
     return this.http.post(`${ApiSettings.getApiBaseURL()}facilityManagers/current/facilityMail/`, params, {
                             withCredentials: true,

--- a/src/app/facility_manager/facilityprojectsoverview.component.html
+++ b/src/app/facility_manager/facilityprojectsoverview.component.html
@@ -307,7 +307,7 @@
                     }"></textarea>
               </div>
             </div>
-            <div *ngIf="selectedProjectType == 'ALL'" class="form-group row">
+            <div *ngIf="selectedProjectType == 'ALL' && sendNews" class="form-group row">
               <label class="col-md-12 control-label"><strong>Alternative newstext (optional)</strong></label>
               <div class="col-md-12">
                             <textarea class="form-control" id="alternative_emailText"
@@ -316,13 +316,17 @@
                                       type="text"></textarea>
               </div>
             </div>
-            <div *ngIf="selectedProjectType == 'ALL'" class="form-group row">
-              <label class="col-md-12 control-label"><strong>Additional tags (optional - seperate by commas)</strong></label>
-              <div class="col-md-12">
-                            <textarea class="form-control" id="news_tags"
-                                      name="news_tags"
-                                      [(ngModel)]="news_tags"
-                                      type="text"></textarea>
+            <div *ngIf="selectedProjectType == 'ALL' && sendNews" class="form-group row">
+              <label class="col-md-12 control-label"><strong>Tags:</strong></label>
+              <div class="form-check" id="tags_check">
+                <div *ngFor="let tag of availableNewsTags">
+                  <div class="form-row col-md-6">
+                    <input class="form-check-input" type="checkbox" id="checkbox_{{tag.id.toString()}}"
+                           (click)="manageTags(tag)"
+                           [checked]="selectedTags?.indexOf(tag.id.toString()) > -1">
+                    <label class="form-check-label" for="checkbox_{{tag.id.toString()}}">{{tag.name}}</label>
+                  </div>
+                </div>
               </div>
             </div>
           </form>
@@ -373,7 +377,7 @@
       </div>
       <div class="modal-footer">
         <button class="btn  btn-success col-md-4"
-                (click)="sendMailToFacility(selectedFacility['FacilityId'], emailSubject, emailText, emailReply, sendNews, alternative_emailText, news_tags);
+                (click)="sendMailToFacility(selectedFacility['FacilityId'], emailSubject, emailText, emailReply, sendNews, alternative_emailText);
                 verifyModal.hide();
                 resetEmailModal();
                 successModal.show()">

--- a/src/app/facility_manager/facilityprojectsoverview.component.ts
+++ b/src/app/facility_manager/facilityprojectsoverview.component.ts
@@ -6,14 +6,14 @@ import {ApiSettings} from '../api-connector/api-settings.service';
 import {GroupService} from '../api-connector/group.service';
 import {UserService} from '../api-connector/user.service';
 import {FacilityService} from '../api-connector/facility.service';
-import {NewsService} from "../api-connector/news.service";
+import {NewsService} from '../api-connector/news.service';
 import * as moment from 'moment';
 import {ComputecenterComponent} from '../projectmanagement/computecenter.component';
 import {FilterBaseClass} from '../shared/shared_modules/baseClass/filter-base-class';
 import {IResponseTemplate} from '../api-connector/response-template';
 import {Subject} from 'rxjs';
 import {debounceTime, distinctUntilChanged} from 'rxjs/operators';
-import {WordPressTag} from "./newsmanagement/wp-tags";
+import {WordPressTag} from './newsmanagement/wp-tags';
 
 /**
  * Facility Project overview component.

--- a/src/app/facility_manager/facilityprojectsoverview.component.ts
+++ b/src/app/facility_manager/facilityprojectsoverview.component.ts
@@ -6,12 +6,14 @@ import {ApiSettings} from '../api-connector/api-settings.service';
 import {GroupService} from '../api-connector/group.service';
 import {UserService} from '../api-connector/user.service';
 import {FacilityService} from '../api-connector/facility.service';
+import {NewsService} from "../api-connector/news.service";
 import * as moment from 'moment';
 import {ComputecenterComponent} from '../projectmanagement/computecenter.component';
 import {FilterBaseClass} from '../shared/shared_modules/baseClass/filter-base-class';
 import {IResponseTemplate} from '../api-connector/response-template';
 import {Subject} from 'rxjs';
 import {debounceTime, distinctUntilChanged} from 'rxjs/operators';
+import {WordPressTag} from "./newsmanagement/wp-tags";
 
 /**
  * Facility Project overview component.
@@ -19,7 +21,7 @@ import {debounceTime, distinctUntilChanged} from 'rxjs/operators';
 @Component({
              selector: 'app-facility-projects',
              templateUrl: 'facilityprojectsoverview.component.html',
-             providers: [FacilityService, UserService, GroupService, ApiSettings]
+             providers: [FacilityService, UserService, GroupService, ApiSettings, NewsService]
            })
 export class FacilityProjectsOverviewComponent extends FilterBaseClass implements OnInit {
 
@@ -59,10 +61,13 @@ export class FacilityProjectsOverviewComponent extends FilterBaseClass implement
 
   public managerFacilities: [string, number][];
   public selectedFacility: [string, number];
+  private availableNewsTags: WordPressTag[] = [];
+  private selectedTags: string[] = [];
   projects_filtered: Project[] = [];
 
   constructor(private groupservice: GroupService,
-              private facilityservice: FacilityService) {
+              private facilityservice: FacilityService,
+              private newsService: NewsService) {
     super();
   }
 
@@ -85,6 +90,12 @@ export class FacilityProjectsOverviewComponent extends FilterBaseClass implement
       .subscribe(() => {
         this.applyFilter();
       });
+    this.newsService.getAvailableTagsFromWordPress().subscribe((result: any) => {
+      if (result) {
+        this.availableNewsTags = result.map((tag: any) =>
+          (new WordPressTag({name: tag['name'], id: tag['id']} as WordPressTag)));
+      }
+    });
   }
 
   getProjectsByMemberElixirId(): void {
@@ -292,12 +303,35 @@ export class FacilityProjectsOverviewComponent extends FilterBaseClass implement
 
   }
 
+  /**
+   * Adds or deletes tags from the list of tags to add to the news when the corresponding checkbox gets clicked.
+   * @param tag the tag which gets added/deleted.
+   */
+  manageTags(tag: WordPressTag): void {
+    const index: number = this.selectedTags.indexOf(tag.id.toString());
+    if (index > -1) {
+      this.selectedTags.splice(index, 1);
+    } else {
+      this.selectedTags.push(tag.id.toString());
+    }
+  }
+
+  /**
+   * Sends an email to users and also posts it as a news in WordPress via newsManager if selected.
+   * @param facility the facility of the users which shall be informed
+   * @param subject the subject as a string
+   * @param message the message as a string
+   * @param reply the reply-address
+   * @param send boolean if it should be sent to WordPress
+   * @param alternative_news_text the news text for WordPress, in case it shall be different from the original text
+   */
   sendMailToFacility(facility: string, subject: string, message: string, reply?: string,
-                     send?: any, alternative_news_text?: string, news_tags?: string): void {
+                     send?: any, alternative_news_text?: string): void {
     this.emailStatus = 0;
+    const chosenTags: string = this.selectedTags.toString();
     this.facilityservice.sendMailToFacility(
       facility, encodeURIComponent(subject), encodeURIComponent(message), this.selectedProjectType,
-      encodeURIComponent(reply), send, encodeURIComponent(alternative_news_text), encodeURIComponent(news_tags)).subscribe(
+      encodeURIComponent(reply), send, encodeURIComponent(alternative_news_text), chosenTags).subscribe(
       (result: any) => {
         if (result.status === 201) {
           this.emailStatus = 1;


### PR DESCRIPTION
@dweinholz
facility emails send to ALL and with option "also send to news" enabled now send to wordpress (news also seen in news manager tab). Added possibility to select all tags which are provided from wordpress.
needs https://github.com/deNBI/cloud-api/pull/1612

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

