### PR TITLE
fix(News Management): news not shown in manager

### DIFF
--- a/src/app/facility_manager/newsmanagement/news-manager.component.ts
+++ b/src/app/facility_manager/newsmanagement/news-manager.component.ts
@@ -198,11 +198,8 @@ export class NewsManagerComponent implements OnInit {
     this.wordPressNews = [];
     const facility_ids: string[] = this.selectedFacilities.map((facility: [string, number]): string => facility['FacilityId'].toString());
     this.newsService.getNewsFromWordPress(facility_ids.toString()).subscribe((result: Object[]): any => {
-      if (!('code' in result) && result['code'] === 'wp-die') {
-
         this.wordPressNews = result.map((news: Object): any => this.createWordPressNews(news));
         this.setNews();
-      }
     });
 
   }


### PR DESCRIPTION
Try to fulfill the following points before the Pull Request is merged:

@eKatchko should show facility news from wordpress again

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

