### PR TITLE
upper limit for research tags #1879 

### DIFF
--- a/src/app/applications/application-formular/application-formular.component.html
+++ b/src/app/applications/application-formular/application-formular.component.html
@@ -417,8 +417,10 @@
               <label class="col-md-4 form-control-label"><strong>Research Topics* </strong></label>
               <div class="col-md-8" style="  z-index: 999;" >
                 <div [ngClass]="{
-                                'danger-border': application?.project_application_edam_terms?.length <=0,
+                                'danger-border': application?.project_application_edam_terms?.length <=0
+                                || application?.project_application_edam_terms?.length >10,
                                 'success-border':application?.project_application_edam_terms?.length >0
+                                && application?.project_application_edam_terms?.length <=10
                                 }">
                   <ng-autocomplete #edam_ontology id="edam_input"
                                    [data]="edam_ontology_terms"
@@ -447,8 +449,10 @@
                   <span class="badge" style="cursor: pointer;"
                         (click)="application.removeEdamTerm(term)">&#10060;</span>
  </span>
-
                 </h5>
+                <div *ngIf="application?.project_application_edam_terms?.length>10" class="alert alert-warning" role="alert">
+                  You can at most choose 10 research topics for your project.
+                </div>
               </div>
             </div>
             <div class="form-group row">
@@ -990,7 +994,7 @@
             Please select at least one flavor.
           </div>
           <div
-            *ngIf="form.invalid ||application?.project_application_edam_terms.length == 0 || (application?.flavors.length == 0  && !application?.project_application_openstack_project) || (!application?.dissemination.isPlatformSelected() && application?.project_application_report_allowed)"
+            *ngIf="form.invalid ||application?.project_application_edam_terms.length == 0 || application?.project_application_edam_terms.length > 10|| (application?.flavors.length == 0  && !application?.project_application_openstack_project) || (!application?.dissemination.isPlatformSelected() && application?.project_application_report_allowed)"
             class="form-group row alert alert-warning">
             Some required fields are incorrect or not filled in yet.
             Please check if all required (*) fields are filled in correctly.
@@ -1023,7 +1027,7 @@
             </div>
             <label class="col-md-4 form-control-label">
               <button (click)="notificationModal.show();approveApplication(form);"
-                      [disabled]="!respCheck.checked || form.invalid  ||application?.project_application_edam_terms.length == 0  || (application?.flavors.length == 0  && !application?.project_application_openstack_project)|| (!application?.dissemination?.isPlatformSelected()  && application?.project_application_report_allowed)"
+                      [disabled]="!respCheck.checked || form.invalid  ||application?.project_application_edam_terms.length == 0  || application?.project_application_edam_terms.length > 10 || (application?.flavors.length == 0  && !application?.project_application_openstack_project)|| (!application?.dissemination?.isPlatformSelected()  && application?.project_application_report_allowed)"
 
                       class="btn btn-sm btn-success">
                 <i class="fa fa-dot-circle-o"></i>
@@ -1036,7 +1040,7 @@
             <button *ngIf="!is_validation"
                     (click)="filterEnteredData(form);calculateInitialCredits(form); submitModal.show();"
                     id="submit_btn"
-                    [disabled]="submitting || form.invalid  ||application?.project_application_edam_terms.length == 0  || (application?.flavors.length == 0  && !application?.project_application_openstack_project) || (!application?.dissemination?.isPlatformSelected()  && application?.project_application_report_allowed)"
+                    [disabled]="submitting || form.invalid  ||application?.project_application_edam_terms.length == 0 || application?.project_application_edam_terms.length > 10 || (application?.flavors.length == 0  && !application?.project_application_openstack_project) || (!application?.dissemination?.isPlatformSelected()  && application?.project_application_report_allowed)"
                     class="btn btn-sm btn-success"
                     type="button"><i
               class="fa fa-dot-circle-o"></i> Submit

--- a/src/app/projectmanagement/overview.component.html
+++ b/src/app/projectmanagement/overview.component.html
@@ -201,7 +201,7 @@
             <div class="col-6">
               <div class="callout callout-info" *ngIf="this.resourceDataLoaded">
                 <small class="text-muted">Virtual machines</small><br>
-                <strong class="text-muted" *ngIf="project?.OpenStackProject">{{maximumVMs}} VMs with a total of 
+                <strong class="text-muted" *ngIf="project?.OpenStackProject">{{maximumVMs}} VMs with a total of
                   {{project_application?.project_application_total_cores}} VCPUs and
                   {{project_application?.project_application_total_ram}} GBs of RAM
                   <span *ngIf="((project_application | hasstatusinlist: Application_States.MODIFICATION_REQUESTED)
@@ -1395,8 +1395,10 @@
               <label class="col-md-4 form-control-label"><strong>Research Topics* </strong></label>
               <div class="col-md-8">
                 <div [ngClass]="{
-                                'danger-border': selected_ontology_terms?.length <=0,
-                                'success-border':selected_ontology_terms?.length >0
+                                'danger-border': selected_ontology_terms.length <=0
+                                || selected_ontology_terms.length >10,
+                                'success-border':selected_ontology_terms.length >0
+                                && selected_ontology_terms?.length <=10
                                 }">
                   <ng-autocomplete #edam_ontology id="edam_input"
                                    [data]="edam_ontology_terms"
@@ -1416,17 +1418,17 @@
                     <div [innerHTML]="notFound"></div>
                   </ng-template>
 
-
                 </div>
                 <h5><span
-
                   *ngFor="let term of selected_ontology_terms"
                   style="margin-right: 5px; "
                   class="badge badge-info"> {{term.term}}
                   <span class="badge" style="cursor: pointer;" (click)="removeEDAMterm(term)">&#10060;</span>
- </span>
-
+              </span>
                 </h5>
+                <div *ngIf="selected_ontology_terms.length>10" class="alert alert-warning" role="alert">
+                  You can at most choose 10 research topics for your project.
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
@vktrrdk 

As this feature is small I believe one reviewer is sufficient.

Prevents user from choosing more than 10 research tags (project application and project extension view). Displays an error message. 
I did not find other instances where one can choose research tags. If you know any please let me know and I will add this feature to that site too.

How to test: Try to choose 11 or more research tags: a warning should be displayed and the submission button should be deactivated.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

