### PR TITLE
fix(vm): no jumping cards, show deleting status, deleteAll working, progress bar for new vm redirect

### DIFF
--- a/src/app/pipe-module/pipe-module.module.ts
+++ b/src/app/pipe-module/pipe-module.module.ts
@@ -2,14 +2,14 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {FlavorCounterPipe} from './pipes/flavorcounter';
 import { HasstatusinlistPipe } from './pipes/hasstatusinlist.pipe';
-import {HasStatusPipe} from './pipes/has-status.pipe';
+import {HasStatusPipe, StatusInProcessPipe} from './pipes/has-status.pipe';
 
 /**
  * Pipemodule
  */
 @NgModule({
-            declarations: [FlavorCounterPipe, HasStatusPipe, HasstatusinlistPipe],
-            exports: [FlavorCounterPipe, HasStatusPipe, HasstatusinlistPipe],
+            declarations: [FlavorCounterPipe, HasStatusPipe, HasstatusinlistPipe, StatusInProcessPipe],
+            exports: [FlavorCounterPipe, HasStatusPipe, HasstatusinlistPipe, StatusInProcessPipe],
             imports: [
               CommonModule
             ]

--- a/src/app/pipe-module/pipes/has-status.pipe.ts
+++ b/src/app/pipe-module/pipes/has-status.pipe.ts
@@ -13,3 +13,17 @@ export class HasStatusPipe implements PipeTransform {
   }
 
 }
+/**
+ * Pipe which checks if status is in a list.
+ */
+@Pipe({
+  name: 'statusInProcess'
+})
+export class StatusInProcessPipe implements PipeTransform {
+
+  transform(status: string, status_list_to_compare: string[]): boolean {
+
+    return status_list_to_compare.indexOf(status) !== -1;
+  }
+
+}

--- a/src/app/projectmanagement/overview.component.ts
+++ b/src/app/projectmanagement/overview.component.ts
@@ -929,7 +929,6 @@ export class OverviewComponent extends ApplicationBaseClassComponent implements 
         this.project_members.push(projectMember);
 
       }
-      console.log(this.isAdmin)
       if (this.isAdmin) {
         this.groupService.getGroupAdminIds(this.project_id).subscribe((result: any): void => {
           const adminIds: any = result['adminIds'];

--- a/src/app/projectmanagement/project-os-details/project-os-details.component.ts
+++ b/src/app/projectmanagement/project-os-details/project-os-details.component.ts
@@ -26,7 +26,6 @@ export class ProjectOsDetailsComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    console.log(this.project.Id)
     this.details_loaded = false;
     this.getProjectDetails()
   }

--- a/src/app/virtualmachines/addvm.component.html
+++ b/src/app/virtualmachines/addvm.component.html
@@ -677,6 +677,13 @@
       </div>
       <div class="modal-body">
         <p>Redirecting to Instance Overview...</p>
+        <div class="progress">
+          <div class="progress-bar progress-bar-striped {{progress_bar_animated}} bg-info"
+               role="progressbar" style="width: 0%;"
+               aria-valuemin="0"
+               aria-valuemax="100" [style.width.%]="progress_bar_width">
+          </div>
+        </div>
         <span [hidden]="true" *ngIf="newVm?.name" id="new_vm_name">{{newVm?.name}}</span>
       </div>
     </div><!-- /.modal-content -->

--- a/src/app/virtualmachines/addvm.component.ts
+++ b/src/app/virtualmachines/addvm.component.ts
@@ -49,6 +49,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
   PREPARE_PLAYBOOK_STATUS: string = 'Prepare Playbook Build...';
   BUIDLING_PLAYBOOK_STATUS: string = 'Building Playbook...';
   ANIMATED_PROGRESS_BAR: string = 'progress-bar-animated';
+  redirectProgress: string = '0';
 
   newVm: VirtualMachine = null;
   progress_bar_status: string = 'Creating..';
@@ -465,6 +466,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
    * @param {string} projectid
    */
   startVM(flavor: string, servername: string, project: string, projectid: string | number): void {
+    this.progress_bar_width = 25;
     this.create_error = null;
     // tslint:disable-next-line:no-complex-conditionals
     if (this.selectedImage && flavor && servername && project) {
@@ -488,7 +490,9 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
       if (!this.mosh_mode_available) {
         this.udp_allowed = false;
       }
-
+      this.delay(500).then((): any => {
+        this.progress_bar_width = 50
+      });
       this.virtualmachineservice.startVM(
         flavor_fixed, this.selectedImage, servername,
         project, projectid.toString(), this.http_allowed,
@@ -498,6 +502,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
           this.started_machine = false;
 
           if (newVm.status === 'Build') {
+            this.progress_bar_width = 75;
             setTimeout(
               (): void => {
                 this.router.navigate(['/virtualmachines/vmOverview']).then().catch()
@@ -512,6 +517,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
               1000)
           } else if (newVm.status) {
             this.newVm = newVm;
+            this.progress_bar_width = 75;
             setTimeout(
               (): void => {
                 this.router.navigate(['/virtualmachines/vmOverview']).then().catch()
@@ -529,12 +535,16 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
       this.newVm = null;
 
     }
-    setTimeout(
-      (): void => {
-        this.router.navigate(['/virtualmachines/vmOverview']).then().catch()
-      },
-      2000)
+    // setTimeout(
+    //   (): void => {
+    //     this.router.navigate(['/virtualmachines/vmOverview']).then().catch()
+    //   },
+    //   2000)
 
+  }
+
+  async delay(ms: number): Promise<any> {
+    await new Promise((resolve: any): any => setTimeout(resolve, ms));
   }
 
   getPlaybookInformation(): string {

--- a/src/app/virtualmachines/addvm.component.ts
+++ b/src/app/virtualmachines/addvm.component.ts
@@ -492,7 +492,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
       }
       this.delay(500).then((): any => {
         this.progress_bar_width = 50
-      });
+      }).catch((): any => {});
       this.virtualmachineservice.startVM(
         flavor_fixed, this.selectedImage, servername,
         project, projectid.toString(), this.http_allowed,
@@ -544,7 +544,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
   }
 
   async delay(ms: number): Promise<any> {
-    await new Promise((resolve: any): any => setTimeout(resolve, ms)).then((): any => {});
+    await new Promise((resolve: any): any => setTimeout(resolve, ms));
   }
 
   getPlaybookInformation(): string {

--- a/src/app/virtualmachines/addvm.component.ts
+++ b/src/app/virtualmachines/addvm.component.ts
@@ -544,7 +544,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
   }
 
   async delay(ms: number): Promise<any> {
-    await new Promise((resolve: any): any => setTimeout(resolve, ms));
+    await new Promise((resolve: any): any => setTimeout(resolve, ms)).then((): any => {});
   }
 
   getPlaybookInformation(): string {

--- a/src/app/virtualmachines/flavordetail.component.ts
+++ b/src/app/virtualmachines/flavordetail.component.ts
@@ -75,7 +75,6 @@ export class FlavorDetailComponent implements OnInit {
   setSelectedFlavor(flavor: Flavor): void {
 
     this.selectedFlavor = flavor;
-    console.log(this.selectedFlavor);
     this.selectedFlavorChange.emit(this.selectedFlavor);
 
   }

--- a/src/app/virtualmachines/virtualmachinemodels/virtualmachinestates.ts
+++ b/src/app/virtualmachines/virtualmachinemodels/virtualmachinestates.ts
@@ -182,4 +182,8 @@ export class VirtualMachineStates {
   public get staticNOT_IN_PROCESS_STATE(): string[] {
     return VirtualMachineStates.NOT_IN_PROCESS_STATES;
   }
+
+  public get staticIN_PROCESS_STATE(): string[] {
+    return VirtualMachineStates.IN_PROCESS_STATES;
+  }
 }

--- a/src/app/virtualmachines/vmOverview.component.html
+++ b/src/app/virtualmachines/vmOverview.component.html
@@ -54,65 +54,65 @@
 
     <div class="container-fluid">
 
-        <div class="row">
+      <div class="row">
 
-          <div class="col-10 input-group">
-            <div class="input-group-prepend">
-              <div class="input-group-text" *ngIf="is_vo_admin || cluster_allowed">
-                <input type="checkbox" [checked]="filter_cluster" style="margin:2px;"
-                       (change)="filter_cluster=!filter_cluster">
-                <span class="badge badge-info">Cluster</span>
-              </div>
-              <div class="input-group-text">
-                <input type="checkbox" [checked]="filter_set_for_termination" style="margin:2px;"
-                       (change)="filter_set_for_termination=!filter_set_for_termination">
-                <span class="badge badge-secondary">Set for termination</span>
-              </div>
-              <div class="input-group-text">
-                <input type="checkbox" checked style="margin:2px;"
-                       (change)="changeFilterStatus(VirtualMachineStates.staticACTIVE)">
-                <span class="badge badge-success">{{VirtualMachineStates.staticACTIVE}}</span>
-              </div>
-              <div class="input-group-text">
-                <input type="checkbox" checked style="margin:2px;"
-                       (change)="changeFilterStatus(VirtualMachineStates.staticSHUTOFF)">
-                <span class="badge badge-warning">{{VirtualMachineStates.staticSHUTOFF}}</span>
-              </div>
-              <div class="input-group-text">
-                <input type="checkbox" style="margin:2px;"
-                       (change)="changeFilterStatus(VirtualMachineStates.staticDELETED)">
-                <span class="badge badge-danger">{{VirtualMachineStates.staticDELETED}}</span>
-              </div>
+        <div class="col-10 input-group">
+          <div class="input-group-prepend">
+            <div class="input-group-text" *ngIf="is_vo_admin || cluster_allowed">
+              <input type="checkbox" [checked]="filter_cluster" style="margin:2px;"
+                     (change)="filter_cluster=!filter_cluster">
+              <span class="badge badge-info">Cluster</span>
             </div>
-              <div class="input-group-text col-5">
-                <input type="text" checked style="margin:2px;" placeholder="user,project,elixir_id,openstackid,name,flavor"
-                       [(ngModel)]="filter" style="width:100%">
-              </div>
-            <div class="input-group-append">
-              <button class="btn btn-outline-primary"(click)="applyFilter()">Filter</button>
+            <div class="input-group-text">
+              <input type="checkbox" [checked]="filter_set_for_termination" style="margin:2px;"
+                     (change)="filter_set_for_termination=!filter_set_for_termination">
+              <span class="badge badge-secondary">Set for termination</span>
             </div>
-
+            <div class="input-group-text">
+              <input type="checkbox" checked style="margin:2px;"
+                     (change)="changeFilterStatus(VirtualMachineStates.staticACTIVE)">
+              <span class="badge badge-success">{{VirtualMachineStates.staticACTIVE}}</span>
+            </div>
+            <div class="input-group-text">
+              <input type="checkbox" checked style="margin:2px;"
+                     (change)="changeFilterStatus(VirtualMachineStates.staticSHUTOFF)">
+              <span class="badge badge-warning">{{VirtualMachineStates.staticSHUTOFF}}</span>
+            </div>
+            <div class="input-group-text">
+              <input type="checkbox" style="margin:2px;"
+                     (change)="changeFilterStatus(VirtualMachineStates.staticDELETED)">
+              <span class="badge badge-danger">{{VirtualMachineStates.staticDELETED}}</span>
+            </div>
           </div>
-
-          <div class="col-2">
-            <div *ngIf="vms_content.length > 0">
-              <div class="dropdown" dropdown>
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="actionDropdownMenu" data-toggle="dropdown"
-                        type="button" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-split"
-                        dropdownToggle id="vmActionsDropdown" style="width:100%">
-                  Actions
-                </button>
-                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu" role="menu"
-                     *dropdownMenu id="dropdownMenu">
-                  <button class="dropdown-item btn btn-secondary" id="deleteAllSelectedVMsButton"
-                          (click)="setToBeDeletedVms(); verifyAllModal.show()">
-                    Delete selected VMs</button>
-                </div>
-              </div>
-            </div>
+          <div class="input-group-text col-5">
+            <input type="text" checked style="margin:2px;" placeholder="user,project,elixir_id,openstackid,name,flavor"
+                   [(ngModel)]="filter" style="width:100%">
+          </div>
+          <div class="input-group-append">
+            <button class="btn btn-outline-primary"(click)="applyFilter()">Filter</button>
           </div>
 
         </div>
+
+        <div class="col-2">
+          <div *ngIf="vms_content.length > 0">
+            <div class="dropdown" dropdown>
+              <button class="btn btn-secondary dropdown-toggle" type="button" id="actionDropdownMenu" data-toggle="dropdown"
+                      type="button" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-split"
+                      dropdownToggle id="vmActionsDropdown" style="width:100%">
+                Actions
+              </button>
+              <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu" role="menu"
+                   *dropdownMenu id="dropdownMenu">
+                <button class="dropdown-item btn btn-secondary" id="deleteAllSelectedVMsButton"
+                        (click)="setToBeDeletedVms(); verifyAllModal.show()">
+                  Delete selected VMs</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
 
       <div *ngIf="isSearching" id="search_spinner" style="margin:10px; padding:10px;">
         <div class="spinner-border text-primary" style="display:block; margin:auto;"></div>
@@ -188,8 +188,7 @@
 
               </div>
               <div style="margin-top: 10px; margin-bottom:5px;">
-                <div class="row" style="margin-left: 10px; font-size: 18px; line-height: 27px; height: 27px"
-                     *ngIf="vm.status === VirtualMachineStates.staticACTIVE || vm.status === VirtualMachineStates.staticSHUTOFF">
+                <div class="row" style="margin-left: 10px; font-size: 18px; line-height: 27px; height: 27px">
                   <div *ngIf="vm.volumes?.length > 0" class="col-md-1">
                       <span class="fas fa-hdd" style="font-size: 18px;"
                             data-toggle="tooltip" data-placement="right"
@@ -201,7 +200,7 @@
                   </div>
                   <div *ngIf="vm?.res_env_url" class="col-md-1">
                       <span class="fas fa-globe" style="font-size: 18px; cursor: pointer;" data-toggle="tooltip" data-placement="right"
-                         title="{{'Research Environment installed: ' + resenvInformationByVM[vm.name]}}"
+                            title="{{'Research Environment installed: ' + resenvInformationByVM[vm.name]}}"
                             (click)="this.copyToClipboard(vm?.res_env_url); this.showCopiedMessage(vm.name);">
                           <span class="badge badge-pill badge-secondary" id="{{vm.name + 'resenvSpan'}}"
                                 style="font-size: 10px; position: relative; top: -12px; left: -10px;">
@@ -220,7 +219,7 @@
                           {{this.condaPackagesByVM[vm.openstackid].toString()}}
                           </span>
                       </span>
-                      <span class="fas fa-boxes" style="font-size: 18px;" data-toggle="tooltip" data-placement="right"
+                    <span class="fas fa-boxes" style="font-size: 18px;" data-toggle="tooltip" data-placement="right"
                           title="{{'Number of Conda Packages installed: ' + this.condaPackagesByVM[vm.openstackid].toString()}}"
                           *ngIf="condaPackagesByVM[vm?.openstackid] > 1">
                           <span class="badge badge-pill badge-secondary"
@@ -284,39 +283,43 @@
                 </div>
               </div>
             </div>
-            <div class="card-body p-x-1 py-h"
-                 *ngIf="(vm?.status |hasStatus:VirtualMachineStates.staticACTIVE) || (vm?.status |hasStatus:VirtualMachineStates.staticSHUTOFF)">
+            <div class="card-body p-x-1 py-h">
               <div class="row">
                 <div class="col-4">
-                  <a class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
-                     [id]="'showDetailsButton_'+vm?.name"
-                     [routerLink]="['/virtualmachines/detail/' + vm?.openstackid]">Show VM details/logs</a>
+                  <button class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
+                          [id]="'showDetailsButton_'+vm?.name"
+                          [disabled]="!(vm?.status |hasStatus:VirtualMachineStates.staticACTIVE)
+                          && !(vm?.status |hasStatus:VirtualMachineStates.staticSHUTOFF)
+                          && !(vm?.status |hasStatus:VirtualMachineStates.staticDELETED)"
+                          [routerLink]="['/virtualmachines/detail/' + vm?.openstackid]">Show VM details/logs</button>
                 </div>
 
-                <div class="col-4"
-                     *ngIf="!(vm?.status |hasStatus:VirtualMachineStates.staticDELETED) && !(vm?.status |hasStatus:VirtualMachineStates.staticSHUTOFF)">
-                  <a class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
-                     *ngIf="vm.cardState!= 1"
-                     [id]="'showHowToConnectButton_'+vm?.name"
-                     (click)="selectedVm=vm; vm.cardState=1" >
-                    How to connect ...</a>
+                <div class="col-4">
+                  <button class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
+                          *ngIf="vm.cardState!= 1" [disabled]="!(vm?.status |hasStatus:VirtualMachineStates.staticACTIVE)"
+                          [id]="'showHowToConnectButton_'+vm?.name"
+                          (click)="selectedVm=vm; vm.cardState=1" >
+                    How to connect ...</button>
 
-                  <a class="font-weight-bold font-xs btn-block btn btn-secondary" *ngIf="vm.cardState==1"
-                     [id]="'hideHowToConnectButton_'+vm?.name"
-                     (click)="selectedVm=vm; vm.cardState=0;" >
-                    ... Hide information</a>
+                  <button class="font-weight-bold font-xs btn-block btn btn-secondary" *ngIf="vm.cardState==1"
+                          [id]="'hideHowToConnectButton_'+vm?.name"
+                          (click)="selectedVm=vm; vm.cardState=0;" >
+                    ... Hide information</button>
                 </div>
-                <div class="col-4" *ngIf="!(vm?.status |hasStatus:VirtualMachineStates.staticDELETED)">
-                  <a class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
-                     *ngIf="vm.cardState!=2"
-                     [id]="'showActionsButton_'+vm?.name"
-                     (click)="selectedVm=vm; vm.cardState=2;" >
-                    Show actions ...</a>
+                <div class="col-4">
+                  <button class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
+                          *ngIf="vm.cardState!=2"
+                          [disabled]="(vm?.status | statusInProcess:VirtualMachineStates.staticIN_PROCESS_STATE)
+                          || (vm?.status | hasStatus:VirtualMachineStates.staticNOT_FOUND)
+                          || (vm?.status | hasStatus:VirtualMachineStates.staticERROR)"
+                          [id]="'showActionsButton_'+vm?.name"
+                          (click)="selectedVm=vm; vm.cardState=2;" >
+                    Show actions ...</button>
 
-                  <a class="font-weight-bold font-xs btn-block btn btn-secondary" *ngIf="vm.cardState==2"
-                     [id]="'hideActionsButton_'+vm?.name"
-                     (click)="selectedVm=vm; vm.cardState=0;" >
-                    ... Hide actions</a>
+                  <button class="font-weight-bold font-xs btn-block btn btn-secondary" *ngIf="vm.cardState==2"
+                          [id]="'hideActionsButton_'+vm?.name"
+                          (click)="selectedVm=vm; vm.cardState=0;" >
+                    ... Hide actions</button>
                 </div>
 
 
@@ -335,7 +338,7 @@
 
                   <div class="col-md-2" style="margin: auto" *ngIf="mode.copy_field && mode.copy_field!=''">
                     <div class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
-                    (click)="copyToClipboard(mode.copy_field)">Copy command</div>
+                         (click)="copyToClipboard(mode.copy_field)">Copy command</div>
                   </div>
                 </div>
 
@@ -393,19 +396,19 @@
                   <div class="col-md-2"
                        *ngIf="vm.client.features['VM_REBOOT'] && !(vm?.status |hasStatus:VirtualMachineStates.staticDELETED)">
                     <div class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
-                       [id]="'chooseRebootVMButton_' + vm?.name" (click)="selectedVm=vm; chooseRebootOptionModal.show();">
+                         [id]="'chooseRebootVMButton_' + vm?.name" (click)="selectedVm=vm; chooseRebootOptionModal.show();">
                       Reboot VM
                     </div>
                   </div>
                   <div class="col-md-2" *ngIf="!(vm?.status |hasStatus:VirtualMachineStates.staticDELETED)">
                     <div class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
-                       [id]="'createSnapshotVMButton_' + vm?.name"
-                       (click)="snapshot_vm=vm;resetSnapshotResult();snapshotModal.show();">
+                         [id]="'createSnapshotVMButton_' + vm?.name"
+                         (click)="snapshot_vm=vm;resetSnapshotResult();snapshotModal.show();">
                       Create Snapshot
                     </div>
                   </div>
                   <div class="col-md-2" *ngIf="!(vm?.status |hasStatus:VirtualMachineStates.staticDELETED)">
-                       <div class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
+                    <div class="font-weight-bold font-xs btn-block text-muted btn btn-outline-secondary"
                          [id]="'deleteVMButton_' + vm?.name" (click)="selectedVm=vm;verifyModal.show();">
                       Delete VM
                     </div>
@@ -734,9 +737,9 @@
       <div class="modal-body">
         <div class="alert alert-warning" role="alert">
           Are you sure you want to delete {{selectedVm?.name}}?
-          </div>
+        </div>
 
-         <div class="alert alert-danger" *ngIf="selectedVm?.openstackid == selectedVm?.cluster?.master_instance_openstack_id" role="alert">
+        <div class="alert alert-danger" *ngIf="selectedVm?.openstackid == selectedVm?.cluster?.master_instance_openstack_id" role="alert">
           If you delete the master of a cluster, your worker machines become useless!
         </div>
 

--- a/src/app/virtualmachines/vmdetail/vmstatus/vmstatus.component.ts
+++ b/src/app/virtualmachines/vmdetail/vmstatus/vmstatus.component.ts
@@ -8,7 +8,6 @@ import {VirtualMachine} from '../../virtualmachinemodels/virtualmachine';
 @Component({
              selector: 'app-vmstatus',
              templateUrl: './vmstatus.component.html',
-             changeDetection: ChangeDetectionStrategy.OnPush,
              styleUrls: ['./vmstatus.component.scss']
            })
 export class VmstatusComponent {


### PR DESCRIPTION
@dweinholz 
cards stay same size when checking for status (buttons are disabled depending on status).
added pipe for vm to check if status is in state list.
progress bar for redirect after starting vm, so user feel like something happens.
selectAll deleting working again.
deleting status shown again (had to remove changeDetectionStrategy:onPush in vmStates component).

needs:
https://github.com/deNBI/cloud-portal-client/pull/496
https://github.com/deNBI/cloud-api/pull/2170

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

