### PR TITLE
feat(Volume):if more than 5 volumes attachable show select

### DIFF
--- a/src/app/virtualmachines/addvm.component.html
+++ b/src/app/virtualmachines/addvm.component.html
@@ -172,7 +172,7 @@
                     <div class="col-md-2"></div>
                     <div class="col-md-10">
                       <div class="rTableRow"
-                           [hidden]="!(volumesToMount?.length > 0 || volumesToAttach?.length >0 || !showAttachVol)">
+                           [hidden]="!(volumesToMount?.length > 0 || volumesToAttach?.length >0 || selected_detached_vol)">
                         <div class="rTableHeadNoBorder col-md-3"><strong>Name</strong></div>
                         <div class="rTableHeadNoBorder col-md-4"><strong>Mountpath</strong></div>
                         <div class="rTableHeadNoBorder col-md-2"><strong>Storage</strong></div>
@@ -225,10 +225,11 @@
                           </div>
                         </div>
                       </ng-container>
-                      <ng-container *ngFor="let vol of detached_project_volumes">
-                        <div class="rTableRow" *ngIf="!showAttachVol">
+                      <ng-container
+                        *ngIf="detached_project_volumes.length >= DETACHED_VOL_SWITCH_MAX && !showAttachVol">
+                        <div class="rTableRow" *ngIf="selected_detached_vol">
                           <div class="rTableCellNoBorder">
-                            {{vol.volume_name}}
+                            {{selected_detached_vol.volume_name}}
 
                           </div>
                           <div class="rTableCellNoBorder">
@@ -239,33 +240,85 @@
                               </div>
                               <input type="text" placeholder="volume."
                                      id="volume_attach_mount_path" class="form-control" name="volume_mount_path"
-                                     [(ngModel)]="vol.volume_path"
-                                     [ngClass]="{'is-invalid': !this.checkIfMountPathIsUsable(vol.volume_path),
-                             'is-valid':this.checkIfMountPathIsUsable(vol.volume_path)}">
+                                     [(ngModel)]="selected_detached_vol.volume_path"
+                                     [ngClass]="{'is-invalid': !this.checkIfMountPathIsUsable(selected_detached_vol.volume_path),
+                             'is-valid':this.checkIfMountPathIsUsable(selected_detached_vol.volume_path)}">
 
                             </div>
                           </div>
-                          <div class="rTableCellNoBorder">{{vol.volume_storage}}
+                          <div class="rTableCellNoBorder">{{selected_detached_vol.volume_storage}}
 
 
                           </div>
                           <div class="rTableCellNoBorder">
-                            <button class="btn btn-success" (click)="addAttachVolume(vol)"
-                                    [disabled]="!this.checkIfMountPathIsUsable(vol.volume_path)"
+                            <button class="btn btn-success" (click)="addAttachVolume(selected_detached_vol)"
+                                    [disabled]="!this.checkIfMountPathIsUsable(selected_detached_vol.volume_path)"
                             >Add
                               <span class="fa fa-plus"></span>
                             </button>
 
 
                           </div>
-                           <div class="alert alert-warning">
-                          In a few cases the automatic mounting might not work, then the volume must be <a
-                          href="{{WIKI_VOLUME_OVERVIEW}}"> mounted</a> manually!
-                        </div>
+
 
                         </div>
+                        <select style="margin-bottom: 5px;margin-top: 5px"
+                           class="form-control" name="selected_detached_vol_select"
+                          [(ngModel)]="selected_detached_vol" id="selected_detached_vol_select"
+
+                        >
+                          <option value="undefined" disabled selected hidden> Please
+                            Select
+                          </option>
+                          <option *ngFor="let vol of detached_project_volumes" [ngValue]="vol"
+                                  id="id_option_{{vol.volume_name}}">
+                            {{vol.volume_name}} ({{(vol.volume_storage)}} GB)
+                          </option>
+
+                        </select>
+
+                      </ng-container>
+                      <ng-container *ngIf="detached_project_volumes.length < DETACHED_VOL_SWITCH_MAX">
+                        <ng-container *ngFor="let vol of detached_project_volumes">
+                          <div class="rTableRow" *ngIf="!showAttachVol">
+                            <div class="rTableCellNoBorder">
+                              {{vol.volume_name}}
+
+                            </div>
+                            <div class="rTableCellNoBorder">
+                              <div class="input-group">
+
+                                <div class="input-group-prepend">
+                                  <span class="input-group-text">/mnt/</span>
+                                </div>
+                                <input type="text" placeholder="volume."
+                                       id="volume_attach_mount_path" class="form-control" name="volume_mount_path"
+                                       [(ngModel)]="vol.volume_path"
+                                       [ngClass]="{'is-invalid': !this.checkIfMountPathIsUsable(vol.volume_path),
+                             'is-valid':this.checkIfMountPathIsUsable(vol.volume_path)}">
+
+                              </div>
+                            </div>
+                            <div class="rTableCellNoBorder">{{vol.volume_storage}}
+
+
+                            </div>
+                            <div class="rTableCellNoBorder">
+                              <button class="btn btn-success" (click)="addAttachVolume(vol)"
+                                      [disabled]="!this.checkIfMountPathIsUsable(vol.volume_path)"
+                              >Add
+                                <span class="fa fa-plus"></span>
+                              </button>
+
+
+                            </div>
+
+
+                          </div>
+                        </ng-container>
                       </ng-container>
                     </div>
+
                   </div>
 
 
@@ -334,14 +387,18 @@
                                     </span></div>
                         </div>
                       </div>
-                        <div class="alert alert-warning">
-                          In a few cases the automatic mounting might not work, then the volume must be <a
-                          href="{{WIKI_VOLUME_OVERVIEW}}"> mounted</a> manually!
-                        </div>
 
                       </div>
 
 
+                    </div>
+                    <div class=" form-group col-md-12 row">
+                      <div class="col-md-2"></div>
+
+                      <div class="alert alert-warning" role="alert" *ngIf="volumesToMount?.length > 0 || volumesToAttach?.length >0">
+                        In a few cases the automatic mounting might not work, then the volume must be <a
+                        href="{{WIKI_VOLUME_OVERVIEW}}"> mounted</a> manually!
+                      </div>
                     </div>
 
 

--- a/src/app/virtualmachines/addvm.component.html
+++ b/src/app/virtualmachines/addvm.component.html
@@ -193,7 +193,7 @@
                           </div>
                           <div class="rTableCellNoBorder">
                             <button class="btn btn-danger"
-                                    (click)="removeVolFromList(volumesToMount.indexOf(vol));">Remove
+                                    (click)="removeVolFromList(vol);">Remove
                               <span class="fa fa-trash"></span>
                             </button>
 

--- a/src/app/virtualmachines/addvm.component.ts
+++ b/src/app/virtualmachines/addvm.component.ts
@@ -130,7 +130,8 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
   selectedProjectClient: Client;
 
   detached_project_volumes: Volume[] = [];
-
+  DETACHED_VOL_SWITCH_MAX: number = 5;
+  selected_detached_vol: Volume;
   newCores: number = 0;
   newRam: number = 0;
   newVms: number = 0;
@@ -317,6 +318,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
   }
 
   addAttachVolume(vol: Volume): void {
+    this.selected_detached_vol = null;
     this.volumesToAttach.push(vol);
     this.detached_project_volumes.splice(this.detached_project_volumes.indexOf(vol), 1)
     if (this.detached_project_volumes.length === 0) {
@@ -325,6 +327,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
   }
 
   removeAttachVolume(vol: Volume): void {
+    this.selected_detached_vol = null;
     const idx: number = this.volumesToAttach.indexOf(vol);
     if (idx !== -1) {
       this.volumesToAttach.splice(idx, 1);

--- a/src/app/virtualmachines/addvm.component.ts
+++ b/src/app/virtualmachines/addvm.component.ts
@@ -329,6 +329,7 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
   removeAttachVolume(vol: Volume): void {
     this.selected_detached_vol = null;
     const idx: number = this.volumesToAttach.indexOf(vol);
+    vol.volume_path = null;
     if (idx !== -1) {
       this.volumesToAttach.splice(idx, 1);
       this.detached_project_volumes.push(vol)
@@ -336,12 +337,12 @@ export class VirtualMachineComponent implements OnInit, DoCheck {
     }
   }
 
-  /**
-   * Removes the volume at the position idx from the list of volumes, which will be mounted.
-   * @param idx the index of the volume within the list 'volumesToMount'
-   */
-  removeVolFromList(idx: number): void {
-    this.volumesToMount.splice(idx, 1);
+  removeVolFromList(vol: Volume): void {
+    const idx: number = this.volumesToMount.indexOf(vol)
+    vol.volume_path = null;
+    if (idx > -1) {
+      this.volumesToMount.splice(idx, 1);
+    }
   }
 
   /**


### PR DESCRIPTION
@eKatchko 
If more than 5 volumes attachable at vm start it will show a selection instead of all
(You can change the value in addvm.component.ts ->    DETACHED_VOL_SWITCH_MAX: number = 5; )

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

