### PR TITLE
refactor(vm-detail): ansible logs in own card

### DIFF
--- a/src/app/virtualmachines/vmdetail/vmdetail.component.html
+++ b/src/app/virtualmachines/vmdetail/vmdetail.component.html
@@ -232,19 +232,6 @@
             </div>
           </div>
         </div>
-        <div class="card-footer" *ngIf="conda_logs">
-          <div class="btn-group btn-group-justified">
-            <button type="button" class="btn btn-secondary" (click)="conda_logs.saveAsPDF()" style="margin-right: 5px">
-
-              Download PDF Logs
-            </button>
-            <button type="button" class="btn btn-secondary" (click)="conda_logs.saveAsTxt()">
-
-              Download txt Logs
-            </button>
-
-          </div>
-        </div>
       </div>
 
       <div class="card" style=" " *ngIf="virtualMachine?.volumes.length > 0">
@@ -378,6 +365,7 @@
 
           </div>
         </div>
+
         <div class="card-header"><span class="font-weight-bold text-muted">User management</span></div>
         <div class="card-body">
           <div class="row">
@@ -433,6 +421,26 @@
 
           </div>
         </div>
+      </div>
+
+      <div class="card" *ngIf="conda_logs['status'] !== null">
+        <div class="card-header">
+          Ansible/Conda/Research-environment logs
+        </div>
+        <div class="card-body">
+          <div class="btn-group btn-group-justified">
+            <button type="button" class="btn btn-secondary" (click)="conda_logs.saveAsPDF()" style="margin-right: 5px">
+
+              Download PDF Logs
+            </button>
+            <button type="button" class="btn btn-secondary" (click)="conda_logs.saveAsTxt()">
+
+              Download txt Logs
+            </button>
+
+          </div>
+        </div>
+
       </div>
 
 


### PR DESCRIPTION
@vktrrdk 
Could not recreate bug anymore https://github.com/deNBI/cloud-portal-webapp/issues/2215
But ansible logs are now downloadable from an own card if they exist (before there were no logs if resenv was installed).

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

