### PR TITLE
fix(Overview): Trim filter input to prevent search problems for clust…

### DIFF
--- a/src/app/virtualmachines/clusters/clusteroverview/clusterOverview.component.ts
+++ b/src/app/virtualmachines/clusters/clusteroverview/clusterOverview.component.ts
@@ -120,6 +120,7 @@ export class ClusterOverviewComponent extends AbstractBaseClasse implements OnIn
    * Apply filter to all vms.
    */
   applyFilter(): void {
+    this.filter = this.filter.trim();
     this.isSearching = true;
     if (typeof (this.cluster_per_site) !== 'number' || this.cluster_per_site <= 0) {
       this.cluster_per_site = 7;

--- a/src/app/virtualmachines/vmOverview.component.ts
+++ b/src/app/virtualmachines/vmOverview.component.ts
@@ -172,6 +172,7 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
    * Apply filter to all vms.
    */
   applyFilter(): void {
+    this.filter = this.filter.trim();
     this.isSearching = true;
     if (typeof(this.vm_per_site) !== 'number' || this.vm_per_site <= 0) {
       this.vm_per_site = 7;


### PR DESCRIPTION
fix(Overview): Trim filter input to prevent search problems for clusters and single VMs

@eKatchko just trimming (both cluster and vm) filter models after clickling filter button

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

