### PR TITLE
fix(application): modal open to true for extension modals

### DIFF
--- a/src/app/projectmanagement/overview.component.html
+++ b/src/app/projectmanagement/overview.component.html
@@ -1406,7 +1406,7 @@
                     form="resource_modification_application_form" id="submit_modification_btn"
                     (click)="this.request_type = ExtensionRequestType.MODIFICATION;
                   calculateRamCores(); calculateCreditsResourceModification();
-                  resourceModificationModal.hide(); submitModal.show();"
+                  resourceModificationModal.hide(); setModalOpen(true); submitModal.show();"
                     [disabled]="modificationForm.invalid"><i class="fa fa-dot-circle-o"></i>
               Submit
             </button>
@@ -1689,6 +1689,7 @@
             <button type="button" class="btn  btn-primary"
                     form="credits_application_form" id="submit_extra_credits_btn"
                     (click)="creditsExtensionModal.hide(); this.request_type = ExtensionRequestType.CREDIT;
+                    setModalOpen(true);
                   submitModal.show();" [disabled]="f2.invalid"><i class="fa fa-dot-circle-o"></i>
               Submit
             </button>

--- a/src/app/projectmanagement/overview.component.html
+++ b/src/app/projectmanagement/overview.component.html
@@ -1576,7 +1576,7 @@
             <button type="button" class="btn  btn-primary"
                     form="extension_application_form" id="submit_extension_btn"
                     (click)="calculateCreditsLifeTime(); projectExtensionModal.hide();
-                  this.request_type = ExtensionRequestType.EXTENSION; submitModal.show();"
+                  this.request_type = ExtensionRequestType.EXTENSION; setModalOpen(true); submitModal.show();"
                     [disabled]="extensionForm.invalid || (((project_application?.project_application_edam_terms?.length == 0)
                   || !project_application?.project_application_edam_terms) && selected_ontology_terms.length < 1)">
               <i class="fa fa-dot-circle-o"></i>


### PR DESCRIPTION
@dweinholz 
setModalOpen(true) was missing when changing to submit modal

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

