### PR TITLE
fix(requests): set x-requested-with header for almost all requests

### DIFF
--- a/src/app/api-connector/token-interceptor.ts
+++ b/src/app/api-connector/token-interceptor.ts
@@ -12,11 +12,29 @@ import { Cookie } from 'ng2-cookies';
 export class TokenInterceptor implements HttpInterceptor {
 
 	intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-		const modifiedReq: HttpRequest<any> = req.clone({
-			withCredentials: true,
-			headers: req.headers.set('X-CSRFToken', Cookie.get('csrftoken')),
-		});
+		const skipIntercept: boolean = req.headers.has('skip');
+		const skipXRequestedWith: boolean = req.headers.has('skip-x-requested-with');
 
-		return next.handle(modifiedReq);
+		if (skipIntercept) {
+			req = req.clone({
+				headers: req.headers.delete('skip'),
+			});
+
+			return next.handle(req);
+		} else if (skipXRequestedWith) {
+			const modifiedReq: HttpRequest<any> = req.clone({
+				withCredentials: true,
+				headers: req.headers.set('X-CSRFToken', Cookie.get('csrftoken')).delete('skip-x-requested-with'),
+			});
+
+			return next.handle(modifiedReq);
+		} else {
+			const modifiedReq: HttpRequest<any> = req.clone({
+				withCredentials: true,
+				headers: req.headers.set('X-CSRFToken', Cookie.get('csrftoken')).set('X-Requested-With', 'XMLHttpRequest'),
+			});
+
+			return next.handle(modifiedReq);
+		}
 	}
 }

--- a/src/app/api-connector/user.service.ts
+++ b/src/app/api-connector/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { ApiSettings } from './api-settings.service';
 import { IResponseTemplate } from './response-template';
 
@@ -78,18 +78,21 @@ export class UserService {
 	}
 
 	getOnlyLoggedUserWithRedirect(redirect?: string): Observable<any> {
+		let skip_header: HttpHeaders = new HttpHeaders();
+		skip_header = skip_header.append('skip-x-requested-with', 'true');
+
 		if (redirect && redirect !== '/userinfo' && redirect !== 'redirect') {
 			const params: HttpParams = new HttpParams().set('redirect_after_login', redirect);
 
 			return this.http.get(`${ApiSettings.getApiBase()}loggedUser/`, {
 				withCredentials: true,
 				params,
-
+				headers: skip_header,
 			});
 		} else {
 			return this.http.get(`${ApiSettings.getApiBase()}loggedUser/`, {
 				withCredentials: true,
-
+				headers: skip_header,
 			});
 		}
 


### PR DESCRIPTION
@dweinholz 
Setting X-Requested-With Header for all requests except for getOnlyLoggedUserWithRedirect.

Use with:
https://github.com/deNBI/cloud-api/pull/3066

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

