### PR TITLE
fix(member-guard): emit elixir_id as event when loaded

### DIFF
--- a/src/app/applications/application-detail/information-detail/information-detail.component.ts
+++ b/src/app/applications/application-detail/information-detail/information-detail.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Application } from '../../application.model/application.model';
-import { elixir_id, is_vo } from '../../../shared/globalvar';
+import { global_event, is_vo } from '../../../shared/globalvar';
 
 /**
  * Application informations.
@@ -9,8 +9,18 @@ import { elixir_id, is_vo } from '../../../shared/globalvar';
 	selector: 'app-information-detail',
 	templateUrl: './information-detail.component.html',
 })
-export class InformationDetailComponent {
-  @Input() application: Application;
-  is_vo: boolean = is_vo;
-  elixir_id: string = elixir_id;
+export class InformationDetailComponent implements OnInit {
+	@Input() application: Application;
+	is_vo: boolean = is_vo;
+	elixir_id: string = '';
+
+	ngOnInit() {
+		global_event.subscribe(
+			(result: any) => {
+				if ('elixir_id' in result) {
+					this.elixir_id = result['elixir_id'];
+				}
+			},
+		);
+	}
 }

--- a/src/app/shared/globalvar.ts
+++ b/src/app/shared/globalvar.ts
@@ -1,5 +1,8 @@
+import { EventEmitter } from '@angular/core';
+
 export let is_vo: boolean = false;
 export let elixir_id: string;
+export const global_event: EventEmitter<any> = new EventEmitter();
 
 /**
  * Set vo.
@@ -15,4 +18,5 @@ export function setVO(vo: boolean): void {
  */
 export function setElixirId(id: string): void {
 	elixir_id = id;
+	global_event.emit({ elixir_id });
 }

--- a/src/app/virtualmachines/vmOverview.component.ts
+++ b/src/app/virtualmachines/vmOverview.component.ts
@@ -13,7 +13,7 @@ import { ImageService } from '../api-connector/image.service';
 import { IResponseTemplate } from '../api-connector/response-template';
 import { SnapshotModel } from './snapshots/snapshot.model';
 import { FacilityService } from '../api-connector/facility.service';
-import { elixir_id, is_vo } from '../shared/globalvar';
+import { global_event, is_vo } from '../shared/globalvar';
 
 import { VirtualMachineStates } from './virtualmachinemodels/virtualmachinestates';
 import { GroupService } from '../api-connector/group.service';
@@ -575,7 +575,6 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
 			this.filter, this.filter_status_list, this.filter_cluster, this.filter_set_for_termination,
 		)
 			.subscribe((vms: any): void => {
-				console.log(vms);
 				this.prepareVMS(vms);
 			});
 	}
@@ -726,7 +725,6 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
 		this.getClientForcUrls();
 		this.getVms();
 		this.is_vo_admin = is_vo;
-		this.user_elixir_id = elixir_id;
 		this.get_is_facility_manager();
 		this.facilityService.getManagerFacilities().subscribe((result: any): void => {
 			this.managerFacilities = result;
@@ -749,6 +747,13 @@ export class VmOverviewComponent implements OnInit, OnDestroy {
 			.subscribe((event: any): void => {
 				this.validSnapshotName(event, this.snapshot_vm);
 			});
+		global_event.subscribe(
+			(result: any) => {
+				if ('elixir_id' in result) {
+					this.user_elixir_id = result['elixir_id'];
+				}
+			},
+		);
 	}
 
 	ngOnDestroy(): void {

--- a/src/app/virtualmachines/vmdetail/vmdetail.component.ts
+++ b/src/app/virtualmachines/vmdetail/vmdetail.component.ts
@@ -21,7 +21,7 @@ import { SnapshotModel } from '../snapshots/snapshot.model';
 import { PlaybookService } from '../../api-connector/playbook.service';
 import { BiocondaService } from '../../api-connector/bioconda.service';
 import { ResenvTemplate } from '../conda/resenvTemplate.model';
-import { elixir_id, is_vo } from '../../shared/globalvar';
+import { global_event, is_vo } from '../../shared/globalvar';
 import { WIKI_GUACAMOLE_LINK, WIKI_RSTUDIO_LINK, WIKI_VOLUME_OVERVIEW } from '../../../links/links';
 import { Volume } from '../volumes/volume';
 import { VolumeStates } from '../volumes/volume_states';
@@ -137,11 +137,17 @@ export class VmDetailComponent extends AbstractBaseClass implements OnInit {
 	}
 
 	ngOnInit(): void {
+		global_event.subscribe(
+			(result: any) => {
+				if ('elixir_id' in result) {
+					this.user_elixir_id = result['elixir_id'];
+				}
+			},
+		);
 		this.activatedRoute.params.subscribe((paramsId: any): void => {
 			this.vm_id = paramsId.id;
 			this.getVmCondaLogs();
 			this.getVmById();
-			this.user_elixir_id = elixir_id;
 			this.snapshotSearchTerm
 				.pipe(
 					debounceTime(this.DEBOUNCE_TIME),


### PR DESCRIPTION
@vktrrdk 
Still needed confirmation alert was sometimes not shown in new tab because global variable elixir_id was imported before it was set by member-guard. Now an event is emitted when global variable elixir_id is set. Added subscriptions to this event in places which imported global variable elixir_id.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

