### PR TITLE
fix(gui): added format info box to set public key popup

### DIFF
--- a/src/app/shared/shared_modules/public-key/public-key.component.html
+++ b/src/app/shared/shared_modules/public-key/public-key.component.html
@@ -126,6 +126,9 @@ In case you lose your private key, it is lost permanently!</alert>
         <alert type="danger" *ngIf="!validatePublicKey() && public_key?.length >0">
           <strong>Warning</strong> This is not a valid public key!
         </alert>
+				<alert type="info">
+					Currently supported public key formats are RSA and ECDSA (SHA2, NIST P256, P384 or P521).
+				</alert>
         <textarea rows="8" type="text" class="form-control input-lg" id="public_key_enter_area"
                   placeholder="Please enter a new valid public key." name="public_key" [(ngModel)]="public_key"
                   #publickey></textarea>


### PR DESCRIPTION
@vktrrdk 
An info box with supported key formats is added directly beneath the key-valid-status box when setting public key.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

