### PR TITLE
fix(gui): changed show conditions of messages and buttons to userinfo

### DIFF
--- a/src/app/shared/shared_modules/public-key/public-key.component.html
+++ b/src/app/shared/shared_modules/public-key/public-key.component.html
@@ -20,7 +20,7 @@
       id="setPublicKeyButton">Set Key
       </button>
       <button class="btn btn-primary" style="float: right; margin: 2px" type="button" (click)="copyToClipboard(userinfo?.PublicKey)"
-              *ngIf="public_key != '' || (pubKeyModal.isShown && userinfo?.PublicKey != 'None')"
+              *ngIf="userinfo?.PublicKey != 'None'"
               id="copyPublicKeyButton">Copy Key
       </button>
       </div>
@@ -59,7 +59,7 @@
 
 
         <alert type="danger">
-          <span *ngIf="public_key?.length !=0 ">
+          <span *ngIf="userinfo?.PublicKey != 'None'">
             <strong>Warning!</strong>
             By replacing the current key, all machines started in the future can only be accessed with the new key.
 Already running or created machines remain accessible with the old (and hereby replaced) key.
@@ -91,7 +91,7 @@ In case you lose your private key, it is lost permanently!</alert>
                 (click)="generateKey();generateKeyModal.hide();">Set
         </button>
         <button class="btn  btn-primary col-md-4" type="reset"
-                (click)="public_key = userinfo.PublicKey ;generateKeyModal.hide();">Cancel
+                (click)="generateKeyModal.hide();">Cancel
         </button>
 
       </div>
@@ -157,7 +157,7 @@ In case you lose your private key, it is lost permanently!</alert>
                 class="btn btn-success col-md4" type="button" id="set_new_public_key_button"
                 (click)="importKey(publickey.value);pubKeyModal.hide();">Set
         </button>
-        <button class="btn  btn-primary col-md-4" type="reset" (click)="public_key = userinfo.PublicKey ;pubKeyModal.hide();">Cancel
+        <button class="btn  btn-primary col-md-4" type="reset" (click)="pubKeyModal.hide()">Cancel
         </button>
 
       </div>


### PR DESCRIPTION
@vktrrdk 
Warn messages and Copy Key button are conditioned on userinfo?.PublicKey, not anymore on local public_key which is now only used in set key modal.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

