### PR TITLE
fix(cluster): quick fix to indicate loading of worker count and note in delete modal

### DIFF
--- a/src/app/virtualmachines/clustercard/clustercard.component.html
+++ b/src/app/virtualmachines/clustercard/clustercard.component.html
@@ -1,5 +1,5 @@
 <div class="card instance-card" style="margin-bottom:15px;" [id]="'clusterCard_' + cluster?.cluster_id">
-     
+
       <div class="card-block" >
               <div class="row" style="margin-top: 5px">
                 <div class="col-6" style="margin: auto;">
@@ -35,6 +35,13 @@
                     active</span>
                   </div>
                 </div>
+								<div class="col-12" style="margin-left: 10px" *ngIf="!all_worker_loaded">
+									<div style="font-size: small">
+										<strong>Checking worker count: </strong>
+										<span class="spinner-border text-info spinner-border-sm">
+										</span>
+									</div>
+								</div>
                 <div class="col-12" style="margin-left: 10px" *ngIf="cluster.status !== VirtualMachineStates.staticDELETED ">
                   <div style="font-size: small">
                     <strong *ngIf="cluster?.public_ip">Public IP:</strong> {{cluster?.public_ip}}
@@ -137,5 +144,5 @@
 
               </div>
             </div>
-	  
+
 	  </div>

--- a/src/app/virtualmachines/clusters/clusteroverview/clusterOverview.component.ts
+++ b/src/app/virtualmachines/clusters/clusteroverview/clusterOverview.component.ts
@@ -27,8 +27,8 @@ export const SCALING_SCRIPT_NAME: string = 'scaling.py';
  */
 @Component({
 
-	           selector: 'app-cluster-overview',
-	           templateUrl: './clusterOverview.component.html',
+	selector: 'app-cluster-overview',
+	templateUrl: './clusterOverview.component.html',
 	styleUrls: ['../../vmOverview.component.scss'],
 	providers: [FacilityService, ImageService, UserService,
 		VirtualmachineService, FullLayoutComponent, GroupService, ClientService, GroupService, FlavorService],
@@ -91,14 +91,14 @@ export class ClusterOverviewComponent extends AbstractBaseClass implements OnIni
 	filterChanged: Subject<string> = new Subject<string>();
 
 	constructor(
-private facilityService: FacilityService,
-private groupService: GroupService,
-				private imageService: ImageService,
-private userService: UserService,
-				private virtualmachineservice: VirtualmachineService,
-private fb: FormBuilder,
-				private clipboardService: ClipboardService,
-private flavorService: FlavorService,
+		private facilityService: FacilityService,
+		private groupService: GroupService,
+		private imageService: ImageService,
+		private userService: UserService,
+		private virtualmachineservice: VirtualmachineService,
+		private fb: FormBuilder,
+		private clipboardService: ClipboardService,
+		private flavorService: FlavorService,
 	) {
 		super();
 

--- a/src/app/virtualmachines/modals/delete-cluster/delete-cluster.component.html
+++ b/src/app/virtualmachines/modals/delete-cluster/delete-cluster.component.html
@@ -12,6 +12,10 @@
 		<p>Are you sure you want to delete <strong>{{cluster?.cluster_id}}</strong>? </p>
         This will also delete the virtual machines:
         <p><strong>{{cluster?.master_instance.name}}</strong></p>
+			<p *ngIf="!all_loaded">
+				The worker count is not yet fully loaded and therefore the following list of worker instances is probably not correct.
+				For a correct list of worker instances please wait until all instances reached their targeted status.
+			</p>
         <p *ngFor="let vm of cluster?.worker_instances"><span
                 *ngIf="vm.status !== VirtualMachineStates.staticDELETED && vm.status !== VirtualMachineStates.staticNOT_FOUND"><strong>{{vm.name}}</strong></span>
         </p>

--- a/src/app/virtualmachines/modals/delete-cluster/delete-cluster.component.ts
+++ b/src/app/virtualmachines/modals/delete-cluster/delete-cluster.component.ts
@@ -1,6 +1,4 @@
-import {
-	Component, EventEmitter, OnDestroy,
-} from '@angular/core';
+import { Component, EventEmitter, OnDestroy } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 import { Clusterinfo } from '../../clusters/clusterinfo';
 import { VirtualMachineStates } from '../../virtualmachinemodels/virtualmachinestates';
@@ -17,6 +15,7 @@ export class DeleteClusterComponent implements OnDestroy {
 	VirtualMachineStates: VirtualMachineStates = new VirtualMachineStates();
 
 	cluster: Clusterinfo;
+	all_loaded: boolean = true;
 	public event: EventEmitter<any> = new EventEmitter();
 	private submitted: boolean = false;
 


### PR DESCRIPTION
@dweinholz  
Loading indicator for each cluster card if actual worker count and targeted worker count is not the same.
Also a note in delete modal if both are not the same.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

