### PR TITLE
fix(application): inform about perun id after declining os project

### DIFF
--- a/src/app/applications/applications.component.ts
+++ b/src/app/applications/applications.component.ts
@@ -758,7 +758,12 @@ export class ApplicationsComponent extends ApplicationBaseClassComponent impleme
 		const idx: number = this.all_applications.indexOf(app);
 		this.applicationsService.declineApplication(app.project_application_id).subscribe(
 			(): void => {
-				this.showNotificationModal('Success', 'The Application was declined', 'success');
+				let message: string = 'The Application was declined.';
+				if (app.project_application_openstack_project && app.project_application_perun_id) {
+					message = `The Application was declined. The perun id was ${app.project_application_perun_id},
+					please remember to delete the perun group.`;
+				}
+				this.showNotificationModal('Success', message, 'success');
 				this.all_applications.splice(idx, 1);
 				this.numberOfProjectApplications -= 1;
 			},


### PR DESCRIPTION
@vktrrdk 
If vo declines openstack project after it got a perun id because it was approved once, the decline modal will remind vo about perun id and to delete it manually.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

