### PR TITLE
fix(gui): changed text of type-a personal data in application formular

### DIFF
--- a/src/app/applications/application-formular/application-formular.component.html
+++ b/src/app/applications/application-formular/application-formular.component.html
@@ -498,7 +498,7 @@
 													 data-test-id="project_application_no_personal_data_switch"
 													 (click)="togglePersonalDataType(noPersonalData.checked, 'no_personal_data')"
 													 [(ngModel)]="application.project_application_no_personal_data">
-										<span class="help-block">a) no personal data or sufficiently anonymized data</span>
+										<span class="help-block">a) no personal data or sufficiently anonymized data only</span>
 									</div>
 									<div class="form-check">
 										<input class="form-check-input" type="checkbox"

--- a/src/app/applications/application-formular/application-formular.component.html
+++ b/src/app/applications/application-formular/application-formular.component.html
@@ -498,7 +498,7 @@
 													 data-test-id="project_application_no_personal_data_switch"
 													 (click)="togglePersonalDataType(noPersonalData.checked, 'no_personal_data')"
 													 [(ngModel)]="application.project_application_no_personal_data">
-										<span class="help-block">a) no personal data</span>
+										<span class="help-block">a) no personal data or sufficiently anonymized data</span>
 									</div>
 									<div class="form-check">
 										<input class="form-check-input" type="checkbox"


### PR DESCRIPTION
@vktrrdk 
Adjusted the description of type-a personal-data-checkbox in application formular.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

