### PR TITLE
fix(Applications): Distinguish buttons between OS and SVM approval on modification request

### DIFF
--- a/src/app/applications/applications.component.html
+++ b/src/app/applications/applications.component.html
@@ -387,22 +387,6 @@
 														<span class="d-none">Assign Proccessing VO</span>
 													</button>
 													<button
-														[id]="'modification_approval_' + application?.project_application_shortname"
-														*ngIf="
-															(application | hasstatusinlist : Application_States.MODIFICATION_REQUESTED) &&
-															application?.project_application_openstack_project &&
-															application?.project_modification_request
-														"
-														style="margin: 2px"
-														[attr.data-test-id]="'modification_approval_' + application?.project_application_shortname"
-														(click)="showConfirmationModal(application, 'approveModification')"
-														type="button"
-														class="btn btn-success"
-													>
-														<i class="fa fa-check"></i>&nbsp;
-														<span class="d-none">Approve Modification</span>
-													</button>
-													<button
 														[id]="'modification_adjustment_' + application?.project_application_shortname"
 														[attr.data-test-id]="
 															'modification_adjustment_' + application?.project_application_shortname
@@ -419,10 +403,29 @@
 														<i class="fa fa-pen"></i>&nbsp;
 														<span class="d-none"> Adjust Modification</span>
 													</button>
+
 													<button
 														[id]="'modification_approval_' + application?.project_application_shortname"
 														*ngIf="
 															(application | hasstatusinlist : Application_States.MODIFICATION_REQUESTED) &&
+															application?.project_application_openstack_project &&
+															application?.project_modification_request
+														"
+														style="margin: 2px"
+														[attr.data-test-id]="'modification_approval_' + application?.project_application_shortname"
+														(click)="showConfirmationModal(application, 'approveModification')"
+														type="button"
+														class="btn btn-success"
+													>
+														<i class="fa fa-check"></i>&nbsp;
+														<span class="d-none">Approve Modification</span>
+													</button>
+
+													<button
+														[id]="'modification_approval_' + application?.project_application_shortname"
+														*ngIf="
+															(application | hasstatusinlist : Application_States.MODIFICATION_REQUESTED) &&
+															!application?.project_application_openstack_project &&
 															application?.project_modification_request
 														"
 														style="margin: 2px"


### PR DESCRIPTION
@dweinholz ngif adjustment - and move mod-req-adjustment in front of approval buttons

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

