### PR TITLE
Fix/project requests

### DIFF
--- a/src/app/projectmanagement/modals/result/result.component.ts
+++ b/src/app/projectmanagement/modals/result/result.component.ts
@@ -92,9 +92,8 @@ export class ResultComponent implements OnInit, OnDestroy {
 	submitLifetimeExtensionRequest(): void {
 		this.setToResultState();
 
-		this.applicationsService
-			.requestAdditionalLifetime(this.extension as ApplicationLifetimeExtension)
-			.subscribe((result: { [key: string]: string }): void => {
+		this.applicationsService.requestAdditionalLifetime(this.extension as ApplicationLifetimeExtension).subscribe(
+			(result: { [key: string]: string }): void => {
 				if (result['Error']) {
 					this.extensionStatus = 2;
 					this.errorMessage = result['Error'];
@@ -103,23 +102,32 @@ export class ResultComponent implements OnInit, OnDestroy {
 				}
 
 				this.event.emit({ reload: true });
-			});
+			},
+			() => {
+				this.extensionStatus = 2;
+				this.errorMessage =					'Submitting the extension request was not successful. Please reload this page and try again!';
+			},
+		);
 	}
 
 	submitCreditsModification(): void {
 		this.setToResultState();
 
 		this.subscription.add(
-			this.applicationsService
-				.requestAdditionalCredits(this.extension as ApplicationCreditRequest)
-				.subscribe((result: { [key: string]: string }): void => {
+			this.applicationsService.requestAdditionalCredits(this.extension as ApplicationCreditRequest).subscribe(
+				(result: { [key: string]: string }): void => {
 					if (result['Error']) {
 						this.extensionStatus = 2;
 					} else {
 						this.extensionStatus = 1;
 					}
 					this.event.emit({ reload: true });
-				}),
+				},
+				() => {
+					this.extensionStatus = 2;
+					this.errorMessage = 'Submitting the credit request was not successful. Please reload this page and try again!';
+				},
+			),
 		);
 	}
 

--- a/src/app/projectmanagement/modals/result/result.component.ts
+++ b/src/app/projectmanagement/modals/result/result.component.ts
@@ -59,9 +59,8 @@ export class ResultComponent implements OnInit, OnDestroy {
 		this.setToResultState();
 
 		this.subscription.add(
-			this.applicationsService
-				.requestModification(this.extension as ApplicationModification)
-				.subscribe((result: { [key: string]: string }): void => {
+			this.applicationsService.requestModification(this.extension as ApplicationModification).subscribe(
+				(result: { [key: string]: string }): void => {
 					if (result['Error']) {
 						this.extensionStatus = 2;
 						this.errorMessage = result['Error'];
@@ -70,7 +69,12 @@ export class ResultComponent implements OnInit, OnDestroy {
 					}
 
 					this.event.emit({ reload: true });
-				}),
+				},
+				() => {
+					this.extensionStatus = 2;
+					this.errorMessage =						'Submitting the modification request was not successful. Please reload this page and try again!';
+				},
+			),
 		);
 	}
 
@@ -89,6 +93,7 @@ export class ResultComponent implements OnInit, OnDestroy {
 			),
 		);
 	}
+
 	submitLifetimeExtensionRequest(): void {
 		this.setToResultState();
 


### PR DESCRIPTION
@dweinholz 

When we get an error on the request, we show an error message instead of having the "Waiting...." spinner all the time.
Can be tested by having two sessions and using the same project overview.
When submitting one lifetime/modification request in the one session, and trying to send another one in the second, while the button is still available.

Leads to 403, but the error-possibility was not considered correctly before, so no change in the result-modal was given

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

