### PR TITLE
fix(Application): Edam terms form-control

### DIFF
--- a/src/app/applications/application-formular/application-formular.component.html
+++ b/src/app/applications/application-formular/application-formular.component.html
@@ -716,16 +716,7 @@
 								><strong>Research Topics<i class="fa fa-asterisk" aria-hidden="true"></i> </strong
 							></label>
 							<div class="col-md-8" style="z-index: 999">
-								<div
-									[ngClass]="{
-										'danger-border':
-											application?.project_application_edam_terms?.length <= 0 ||
-											application?.project_application_edam_terms?.length > 10,
-										'success-border':
-											application?.project_application_edam_terms?.length > 0 &&
-											application?.project_application_edam_terms?.length <= 10,
-									}"
-								>
+								<div>
 									<ng-select
 										#edam_ontology
 										id="edam_input"
@@ -733,11 +724,21 @@
 										[items]="edam_ontology_terms"
 										[multiple]="true"
 										bindLabel="term"
+										class="form-control"
 										maxSelectedItems="10"
 										placeholder="Please select at least one topic"
 										dropdownPosition="bottom"
 										[(ngModel)]="application.project_application_edam_terms"
 										name="selected_edam_terms"
+										[ngClass]="{
+											'is-invalid':
+												(form.controls.selected_edam_terms?.invalid ||
+													application.project_application_edam_terms?.length == 0) &&
+												(form.controls.selected_edam_terms?.dirty || form.controls.selected_edam_terms?.touched),
+											'is-valid':
+												form.controls.selected_edam_terms?.valid &&
+												(form.controls.selected_edam_terms?.dirty || form.controls.selected_edam_terms?.touched),
+										}"
 									>
 									</ng-select>
 								</div>

--- a/src/scss/_custom.scss
+++ b/src/scss/_custom.scss
@@ -934,16 +934,6 @@ header {
 }
 
 
-.danger-border {
-    border-style: solid;
-    border-color: red;
-}
-
-.success-border {
-    border-style: solid;
-    border-color: #B0DFC5;
-}
-
 .modal-backdrop {
     position: relative;
 }


### PR DESCRIPTION
@deNBI/portal-dev-hifi or @deNBI/portal-dev  @qqmok 

Fixes the issue, that the border for the EDAM-term entry (Research Topics) was considered as "to aggressively red".
Now uses the style of form-control + valid/invalid.

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

