### PR TITLE
fix(Modification Adjustment): Show all available custom flavors from …

### DIFF
--- a/src/app/applications/applications.component.ts
+++ b/src/app/applications/applications.component.ts
@@ -171,11 +171,7 @@ export class ApplicationsComponent extends ApplicationBaseClassComponent impleme
 			this.isLoaded_userApplication = true
 		}
 		for (const application of applications) {
-			console.log('before')
-			console.log(application)
 			const newApplication = new Application(application)
-			console.log('after')
-			console.log(newApplication)
 
 			this.all_applications.push(newApplication)
 		}

--- a/src/app/projectmanagement/modals/modification-request/modification-request.component.html
+++ b/src/app/projectmanagement/modals/modification-request/modification-request.component.html
@@ -34,8 +34,9 @@
 			<ng-container *ngFor="let flavorType of flavorTypes; first as isFirst">
 				<accordion-group
 					*ngIf="
-						(project?.project_application_openstack_project || shown_flavors[flavorType.long_name]) &&
-						(project | hasFlavorTypeOrIsNotCustom: flavorType)
+						((project?.project_application_openstack_project || shown_flavors[flavorType.long_name]) &&
+							(project | hasFlavorTypeOrIsNotCustom: flavorType)) ||
+						adjustment
 					"
 					[isOpen]="isFirst"
 					#groupval
@@ -49,7 +50,7 @@
 						>
 						</i>
 					</div>
-					<div *ngIf="!flavorRetrievalInProgress; else flavorRetrievalSpinner" >
+					<div *ngIf="!flavorRetrievalInProgress; else flavorRetrievalSpinner">
 						<div *ngFor="let flavor_name of getFlavorNamesByType(flavorType)" class="form-group row my-4 py-2">
 							<div class="col-4">
 								<label class="text-muted" for="{{ flavor_name }}_old">
@@ -163,14 +164,16 @@
 											attr.data-test-id="adjusted_{{ flavorType.shortcut + '_' + i }}"
 											placeholder="e.g 1"
 											[ngModel]="
-												adjusted_project_modification | flavorCounter: shown_flavors[flavorType.long_name][flavor_name][0]
+												adjusted_project_modification
+													| flavorCounter: shown_flavors[flavorType.long_name][flavor_name][0]
 											"
 											#name="ngModel"
 											(change)="checkFlavorPairsAdjustment(shown_flavors[flavorType.long_name][flavor_name][0], $event)"
 											appMinAmount="0"
 											appInteger
 											value="{{
-												adjusted_project_modification | flavorCounter: shown_flavors[flavorType.long_name][flavor_name][0]
+												adjusted_project_modification
+													| flavorCounter: shown_flavors[flavorType.long_name][flavor_name][0]
 											}}"
 											aria-describedby="adjust_{{ flavor_name }}_help"
 											[ngClass]="{
@@ -191,7 +194,7 @@
 					<ng-template #flavorRetrievalSpinner>
 						<div class="spinner-border" role="status">
 							<span class="visually-hidden">Loading flavors..</span>
-						  </div>
+						</div>
 					</ng-template>
 				</accordion-group>
 			</ng-container>
@@ -690,7 +693,6 @@
 				>, so we may calculate and set the correct amount for your project.
 			</strong>
 		</div>
-
 	</form>
 
 	<div *ngIf="modificationForm.invalid || !min_vm" class="alert alert-warning" role="alert">


### PR DESCRIPTION
…VO perspective

@dweinholz 
Seems like this simple adjustments gets us what we want.

1. I checked if users are able to see other custom flavors on modification request submit, if a single custom flavor is assigned to the project --> they cant.
2. For OpenStack Projects one does now always see all custom flavors in the adjustment-view of the VO for modification request. For SimpleVM Projects one does also see all custom flavors, but of course only those that have the simplevm-flag set. 

Please check if this is how we want it.

(Btw. the code for the modification requests is wild)

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] It must be checked if any section in the wiki (https://cloud.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] The PR is responsive on smaller screens.
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] If the new code is readable, if not it should be well commented
- [ ] In case the code is not well commented: An respectice commenting issue with tag "important" is opened.
- [ ] If a squash of commits is required, it has been performed or will be performed at final merge
- [ ] Finally a second team member checks if all requirements met


For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 

